### PR TITLE
Add dry-run verification to publish workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+# Motivation
+
+<!-- Describe the problem or feature request this PR addresses -->
+
+# Approach
+
+<!-- Provide a brief summary of the changes made -->

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,9 +10,22 @@ permissions:
   id-token: write
 
 jobs:
-  publish-npm:
+  verify-jsr:
     runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
 
+      - name: setup deno
+        uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: dry run publish
+        run: deno publish --dry-run
+
+  verify-npm:
+    runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -27,13 +40,39 @@ jobs:
         run: echo ::set-output name=version::$(echo ${{github.ref_name}} | sed 's/^v//')
 
       - name: Setup Node
-        uses: actions/setup-node@v4.1.0
+        uses: actions/setup-node@v6
         with:
-          node-version: 18.x
-          registry-url: https://registry.npmjs.com
+          node-version: 24
 
       - name: Build NPM
         run: deno task build:npm ${{steps.vars.outputs.version}}
+
+      - name: dry run publish
+        run: npm publish --dry-run --tag=verify
+        working-directory: ./build/npm
+
+      - name: upload build
+        uses: actions/upload-artifact@v4
+        with:
+          name: npm-build
+          path: ./build/npm
+
+  publish-npm:
+    needs: [verify-jsr, verify-npm]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.com
+
+      - name: download build
+        uses: actions/download-artifact@v4
+        with:
+          name: npm-build
+          path: ./build/npm
 
       - name: Publish NPM
         run: npm publish --access=public --tag=latest
@@ -42,6 +81,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
   publish-jsr:
+    needs: [verify-jsr, verify-npm]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Motivation

The publish workflow builds and publishes to both npm and JSR in a single shot. If one registry publish succeeds but the other build is broken, we end up with a half-published release that's painful to recover from.

# Approach

Add `verify-jsr` and `verify-npm` gate jobs that perform dry-run publishes before the real thing. Both `publish-npm` and `publish-jsr` now depend on both verify jobs passing. The npm build artifact is uploaded once during verification and reused in the publish step to avoid rebuilding.