### PR TITLE
🐛 Fix empty error message for missing required fields

### DIFF
--- a/lib/field.ts
+++ b/lib/field.ts
@@ -89,9 +89,9 @@ export function field<T>(
         value: undefined as T,
         issues,
       };
+      sources.push(source);
 
       if (!issues) {
-        sources.push(source);
         return {
           ok: true as const,
           value: source.value,

--- a/test/field.test.ts
+++ b/test/field.test.ts
@@ -97,4 +97,11 @@ describe("field", () => {
 
     it.skip("supports custom parsers", () => {});
   });
+
+  it("includes validation issues in the error when no input is provided", () => {
+    let result = parseSync(field(type("number")), {});
+    assert(!result.ok);
+    assert(result.error instanceof ValidationError);
+    expect(result.error.message).toMatch(/must be a number/);
+  });
 });


### PR DESCRIPTION
# Motivation

When a required field has no input sources (no CLI args, env vars, or defaults), the error message is empty. For example, running `staticalize` with no arguments shows blank lines where the validation errors should be:

```
site: 
base: 

`staticalize --help` for available options
```

# Approach

The `ValidationError` was constructed with an empty `sources` array because the "none" source (representing the `undefined` fallback) was only pushed into `sources` on the success path. Moved `sources.push(source)` to happen unconditionally so validation issues are always included in the error message. Added a minimal regression test.