### PR TITLE
Fix missing validation issues in error for empty input

### DIFF
--- a/lib/field.ts
+++ b/lib/field.ts
@@ -89,9 +89,9 @@ export function field<T>(
         value: undefined as T,
         issues,
       };
+      sources.push(source);
 
       if (!issues) {
-        sources.push(source);
         return {
           ok: true as const,
           value: source.value,

--- a/test/field.test.ts
+++ b/test/field.test.ts
@@ -97,4 +97,11 @@ describe("field", () => {
 
     it.skip("supports custom parsers", () => {});
   });
+
+  it("includes validation issues in the error when no input is provided", () => {
+    let result = parseSync(field(type("number")), {});
+    assert(!result.ok);
+    assert(result.error instanceof ValidationError);
+    expect(result.error.message).toMatch(/must be a number/);
+  });
 });


### PR DESCRIPTION
## Motivation

When a field received no input at all and failed validation, the error was missing the validation issues because the source was only pushed to the sources array on the success path. This made it hard to understand why a configuration was rejected.

## Approach

Move `sources.push(source)` before the `ok` check so validation issues are always included in the error, even when no input is provided. Added a test to verify the error message contains the expected validation issue.