### PR TITLE
Fix kebab-case conversion for multi-word CLI options

### DIFF
--- a/lib/case.ts
+++ b/lib/case.ts
@@ -6,7 +6,7 @@ export type KebabCase<S extends string> = ToSnake<S> extends
   `${infer Head}_${infer Tail}` ? `${Head}-${KebabCase<Tail>}` : S;
 
 export function toKebabCase<S extends string>(str: S): KebabCase<S> {
-  return toSnake(str).replace("_", "-") as KebabCase<S>;
+  return toSnake(str).replaceAll("_", "-") as KebabCase<S>;
 }
 
 export function toEnvCase<S extends string>(str: S): EnvCase<S> {

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -240,6 +240,16 @@ describe("object", () => {
 
       expect(result.user).toEqual(["cowboyd", "mz"]);
     });
+    it("kebab-cases multi-word camelCase options", () => {
+      let result = parseOk(
+        object({
+          inspectWatchScopes: field(type("boolean")),
+        }),
+        { args: ["--inspect-watch-scopes"] },
+      );
+
+      expect(result.inspectWatchScopes).toEqual(true);
+    });
     it("can collect arrays of argument values", () => {
       let result = parseOk(
         object({


### PR DESCRIPTION
## Motivation

`toKebabCase` used `String.replace("_", "-")` which only replaces the first underscore. This meant camelCase options with 3+ words (e.g. `inspectWatchScopes`) produced `--inspect-watch_scopes` instead of `--inspect-watch-scopes`.

## Approach

Switch from `replace` to `replaceAll` so all underscores are converted to hyphens. Added a test case for a three-word camelCase option to prevent regression.