### PR TITLE
🐛 Respect Standard Schema transforms (fixes Zod .default())

### DIFF
--- a/lib/field.ts
+++ b/lib/field.ts
@@ -26,12 +26,12 @@ export function field<T>(
 
       // collect object sources
       for (let value of input.values ?? []) {
-        let { issues } = validate(schema, value.value);
+        let result = validate(schema, value.value);
         sources.push({
           sourceName: value.name,
           sourceType: "object",
-          value: value.value as T,
-          issues,
+          value: (result.issues ? value.value : result.value) as T,
+          issues: result.issues,
         });
       }
 
@@ -41,12 +41,12 @@ export function field<T>(
         let strval = env.value[key];
         if (strval === undefined) continue;
         let value = parseEnvValue(field, strval);
-        let { issues } = validate(schema, value);
+        let result = validate(schema, value);
         sources.push({
           sourceName: env.name,
           sourceType: "env",
-          value: value as T,
-          issues,
+          value: (result.issues ? value : result.value) as T,
+          issues: result.issues,
         });
       }
 
@@ -63,15 +63,15 @@ export function field<T>(
 
       // try default
       if (mods.default !== undefined) {
-        let { issues } = validate(schema, mods.default);
+        let result = validate(schema, mods.default);
         let source: Source<T> = {
           sourceName: "default",
           sourceType: "default",
-          value: mods.default as T,
-          issues,
+          value: (result.issues ? mods.default : result.value) as T,
+          issues: result.issues,
         };
         sources.push(source);
-        if (!issues) {
+        if (!result.issues) {
           return {
             ok: true as const,
             value: source.value,
@@ -81,17 +81,17 @@ export function field<T>(
         }
       }
 
-      // try undefined (optional fields)
-      let { issues } = validate(schema, undefined);
+      // try undefined (optional fields or schema-level defaults)
+      let result = validate(schema, undefined);
       let source: Source<T> = {
         sourceName: "none",
         sourceType: "none",
-        value: undefined as T,
-        issues,
+        value: (result.issues ? undefined : result.value) as T,
+        issues: result.issues,
       };
       sources.push(source);
 
-      if (!issues) {
+      if (!result.issues) {
         return {
           ok: true as const,
           value: source.value,

--- a/test/field.test.ts
+++ b/test/field.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { type } from "arktype";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { field } from "../lib/field.ts";
 import assert from "node:assert";
 import { ValidationError } from "../lib/validate.ts";
@@ -60,6 +61,27 @@ describe("field", () => {
       expect(result.value).toEqual(3000);
       expect(result.data.source.sourceType).toEqual("default");
     });
+
+    it("uses a falsy default of false", () => {
+      let result = parseSync(field(type("boolean"), field.default(false)), {});
+      assert(result.ok);
+      expect(result.value).toEqual(false);
+      expect(result.data.source.sourceType).toEqual("default");
+    });
+
+    it("uses a falsy default of 0", () => {
+      let result = parseSync(field(type("number"), field.default(0)), {});
+      assert(result.ok);
+      expect(result.value).toEqual(0);
+      expect(result.data.source.sourceType).toEqual("default");
+    });
+
+    it("uses a falsy default of empty string", () => {
+      let result = parseSync(field(type("string"), field.default("")), {});
+      assert(result.ok);
+      expect(result.value).toEqual("");
+      expect(result.data.source.sourceType).toEqual("default");
+    });
   });
 
   describe("from env", () => {
@@ -96,6 +118,57 @@ describe("field", () => {
     });
 
     it.skip("supports custom parsers", () => {});
+  });
+
+  describe("schema-level defaults", () => {
+    // Simulates a schema that transforms undefined into a default value,
+    // like Zod's z.boolean().default(false) does via Standard Schema.
+    let boolWithDefault: StandardSchemaV1<boolean> = {
+      "~standard": {
+        version: 1,
+        vendor: "test",
+        validate(value) {
+          if (value === undefined) return { value: false };
+          if (value === true || value === false) return { value };
+          return { issues: [{ message: "expected boolean" }] };
+        },
+      },
+    };
+
+    it("applies the schema default when no input is provided", () => {
+      let result = parseSync(field(boolWithDefault), {});
+      assert(result.ok);
+      expect(result.value).toEqual(false);
+    });
+
+    it("uses the provided value over the schema default", () => {
+      let result = parseSync(field(boolWithDefault), {
+        values: [{ name: "test", value: true }],
+      });
+      assert(result.ok);
+      expect(result.value).toEqual(true);
+    });
+
+    it("uses the schema-transformed value from object sources", () => {
+      // A schema that normalizes strings to lowercase
+      let lower: StandardSchemaV1<string> = {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate(value) {
+            if (typeof value === "string") {
+              return { value: value.toLowerCase() };
+            }
+            return { issues: [{ message: "expected string" }] };
+          },
+        },
+      };
+      let result = parseSync(field(lower), {
+        values: [{ name: "test", value: "HELLO" }],
+      });
+      assert(result.ok);
+      expect(result.value).toEqual("hello");
+    });
   });
 
   it("includes validation issues in the error when no input is provided", () => {

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "@std/testing/bdd";
 import { expect } from "@std/expect";
 import { type } from "arktype";
+import type { StandardSchemaV1 } from "@standard-schema/spec";
 import { object } from "../lib/object.ts";
 import { cli, field } from "../lib/field.ts";
 import assert from "node:assert";
@@ -261,6 +262,29 @@ describe("object", () => {
   });
 
   describe("default value", () => {
+    it("applies schema-level defaults when no input is provided", () => {
+      let boolWithDefault: StandardSchemaV1<boolean> = {
+        "~standard": {
+          version: 1,
+          vendor: "test",
+          validate(value) {
+            if (value === undefined) return { value: false };
+            if (value === true || value === false) return { value };
+            return { issues: [{ message: "expected boolean" }] };
+          },
+        },
+      };
+
+      let result = parseOk(
+        object({
+          port: field(type("number"), field.default(3000)),
+          debug: field(boolWithDefault),
+        }),
+        {},
+      );
+      expect(result.port).toEqual(3000);
+      expect(result.debug).toEqual(false);
+    });
   });
 
   describe("nested", () => {


### PR DESCRIPTION
# Motivation

Configliere's field parser ignores the `value` property returned by Standard Schema validation. It destructures only `{ issues }` and uses the original input value. This means schema-level transforms — such as Zod's `.default(false)`, which transforms `undefined` → `false` during `schema["~standard"].validate()` — are silently discarded.

As a result, fields backed by schemas with built-in defaults (e.g., `z.boolean().default(false)`) come back as `undefined` instead of the expected default value.

# Approach

Updated all four `validate()` call sites in `lib/field.ts` to use the schema's output value when validation succeeds. The pattern is the same everywhere:

```ts
// Before
let { issues } = validate(schema, someValue);
value: someValue as T,

// After
let result = validate(schema, someValue);
value: (result.issues ? someValue : result.value) as T,
```

The four sites:

- **Object sources** — use `result.value` instead of raw `value.value`
- **Env sources** — use `result.value` instead of raw parsed env value
- **Mods default** — use `result.value` instead of raw `mods.default`
- **Undefined fallback** — use `result.value` instead of hardcoded `undefined` (this is the critical fix for Zod `.default()`)

This also enables other Standard Schema transforms like coercions and normalizations to work correctly.

**Tests added:**

- Schema-level defaults: a minimal Standard Schema that simulates Zod's `.default(false)` behavior (no new deps)
- Schema transforms: a normalizing schema that lowercases strings, verifying transformed values flow through
- Object-level integration: schema defaults compose correctly with `field.default()` in `object()`
- Falsy `field.default()` coverage: `false`, `0`, and `""` to lock in the `!== undefined` guard