### PR TITLE
Project Tom Hagen: bind environment sources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,13 +32,14 @@ Strongly prefer one-word variable and function names (e.g. `dir` not `tmpDir`,
 
 - Framework: `@std/testing/bdd` (`describe`/`it`) with `@std/expect`
 - Tests live in `test/` and mirror the source layout.
-- Runtime parser tests assert only observable parse outcomes, such as increments,
-  intents, models, routes, and issues. Do not inspect definition internals such
-  as phases, parameters, or children, even when publicly accessible.
+- Runtime parser tests assert only observable parse outcomes, such as
+  increments, intents, models, routes, and issues. Do not inspect definition
+  internals such as phases, parameters, or children, even when publicly
+  accessible.
 - Do not test implementation mechanics such as resolver call counts, timing, or
   traversal order.
-- When replacing an internal assertion, preserve its behavioral contract with
-  an outcome-based test rather than dropping the coverage.
+- When replacing an internal assertion, preserve its behavioral contract with an
+  outcome-based test rather than dropping the coverage.
 
 ### Runtime and tooling
 

--- a/README.md
+++ b/README.md
@@ -1,69 +1,109 @@
 # Configliere
 
-> [!NOTE]
-> Configliere is undergoing a ground-up rebuild. The ideas below are working,
-> but the API is not yet stable.
+**A statically typed entry-point router for command-line applications.**
 
-Configliere models a command-line program as a tree of typed routes. Parsing
-does not merely produce a bag of options: it resolves an intent such as
-`HELP /`, `VERSION /`, or `EXECUTE /serve` and, for execution, binds a model for
-every route that led there.
+An argument parser tells you what the user typed. Configliere tells you where
+and how they intend to enter your program. For execution, it marshals a
+validated, statically typed model for that entry point.
 
-The architecture has four small pieces:
+Configliere matches input to an intent: a method at an application-relative
+route, such as:
 
-- A **route** is an application-relative address such as `/` or `/serve`.
-- A **method** says what to do with that route. Every route supports help;
-  `version()` adds version and `command()` creates an executable route.
-- Each route owns its own **model**. An execute intent contains the current
-  `model` and a path-addressed `models` map for the entire matched lineage.
-- Definitions are immutable composition pipelines. Elements such as
-  `description()`, `option()`, `toggle()`, `version()`, and `routes()` enrich
-  both the runtime definition and its TypeScript type.
+```text
+HELP    /
+VERSION /
+EXECUTE /serve
+HELP    /database/clean
+EXECUTE /database/clean
+```
 
-Parameters are validated with [Standard Schema](https://standardschema.dev/), so
-Configliere works with ArkType, Zod, Valibot, and other conforming schema
-libraries. The examples below use ArkType.
+Every reachable intent appears in the result type. Narrow `method` and `route`,
+and TypeScript knows the exact model available at that entry point.
 
-## One command, one model
+Configliere is not a CLI framework. It does not own handlers, effects, output,
+or process lifetime. It is not a CLI parser whose product is a bag of flags. Its
+product is a typed intent; your application decides what that intent does.
 
-`command()` is an executable route. Here it creates the root route `/` with
-help, version, and execute methods:
+```text
+input → route → method → required binding and validation → intent
+```
+
+## Define every way into the program
+
+`route()` declares an address. `command()` declares an executable route. Every
+route supports help; version and execution exist only where they are explicitly
+added.
+
+Definitions are immutable composition pipelines, not handler registrations:
 
 ```ts
-import process from "node:process";
 import {
   command,
   description,
   name,
   option,
-  parse,
-  printHelp,
-  printVersion,
+  route,
+  routes,
   schema,
   toggle,
   version,
 } from "@frontside/configliere";
-import { type } from "arktype";
+import * as z from "zod";
 
-const app = command(
-  name("server"),
-  description("Run the HTTP server."),
+export const app = command(
+  name("simulacrum"),
+  description("Run and manage local service simulators."),
   version("1.0.0"),
-  option(
-    name("port"),
-    description("Port to listen on."),
-    schema(type("number")),
-  ),
-  toggle(
-    name("verbose"),
-    description("Print request diagnostics."),
+  toggle(name("verbose")),
+  routes(
+    command(
+      name("serve"),
+      option(name("port"), schema(z.number().default(4000))),
+    ),
+    route(
+      name("database"),
+      routes(
+        command(
+          name("clean"),
+          toggle(name("dryRun")),
+        ),
+      ),
+    ),
   ),
 );
+```
+
+That definition makes these entry points—and no others—reachable:
+
+```text
+HELP /                  VERSION /              EXECUTE /
+HELP /serve                                    EXECUTE /serve
+HELP /database
+HELP /database/clean                           EXECUTE /database/clean
+```
+
+The root name identifies the executable; it is not repeated in route IDs.
+`simulacrum serve` therefore selects `/serve`, not `/simulacrum/serve`.
+
+## Route an intent
+
+`parse()` returns a discriminated union of the reachable entry points. Dispatch
+can stay flat even when the route tree is deep:
+
+```ts
+import process from "node:process";
+import {
+  parse,
+  printErrors,
+  printHelp,
+  printVersion,
+} from "@frontside/configliere";
+import { app } from "./app.ts";
 
 const result = parse(app, { argv: process.argv.slice(2) });
 
 if (!result.ok) {
-  console.error(result.code, result);
+  console.error(printErrors(result));
   process.exit(1);
 }
 
@@ -71,142 +111,131 @@ switch (result.method) {
   case "help":
     console.log(printHelp(result));
     break;
+
   case "version":
     console.log(printVersion(result));
     break;
-  case "execute":
-    // Exactly { port: number; verbose: boolean }, not Record<string, unknown>.
-    serve(result.model);
-    break;
-}
 
-function serve(model: { port: number; verbose: boolean }): void {
-  console.log(`listening on ${model.port}; verbose=${model.verbose}`);
+  case "execute":
+    switch (result.route) {
+      case "/":
+        result.model.verbose; // boolean
+        break;
+
+      case "/serve":
+        result.model.port; // number
+        result.models["/"].verbose; // boolean
+        break;
+
+      case "/database/clean":
+        result.model.dryRun; // boolean
+        result.models["/"]; // { verbose: boolean }
+        result.models["/database"]; // {}
+        break;
+    }
 }
 ```
 
-`parse()` receives the arguments _after_ the executable name, which is why the
-example passes `process.argv.slice(2)`. The full command lines above resolve as
-follows:
+An execute intent has two views of configuration:
 
-| Invocation                     | Result                                                                       |
-| ------------------------------ | ---------------------------------------------------------------------------- |
-| `server --help`                | `HELP /`; `printHelp()` renders the route's usage, options, and descriptions |
-| `server --version`             | `VERSION /`; `printVersion()` returns `server 1.0.0`                         |
-| `server --port 4000`           | `EXECUTE /`; `model` is `{ port: 4000, verbose: false }`                     |
-| `server --port=4000 --verbose` | `EXECUTE /`; `model` is `{ port: 4000, verbose: true }`                      |
-| `server --port nope`           | `unprocessable-content`; execution never receives an invalid model           |
+- `model` is owned by the selected route.
+- `models` contains the statically typed model for every route along the
+  selected path. Sibling routes are absent from both the value and its type.
 
-The method is a discriminant. Once the switch reaches `"execute"`, TypeScript
-knows that `model` exists and has exactly the shape assembled by the command's
-parameters. Help and version are resolved before execution validation, so
-`server --help` does not require a port.
+| Invocation                            | Intent and model                                                    |
+| ------------------------------------- | ------------------------------------------------------------------- |
+| `simulacrum --verbose`                | `EXECUTE /` with `{ verbose: true }`                                |
+| `simulacrum serve --port 4100`        | `EXECUTE /serve` with `{ port: 4100 }`                              |
+| `simulacrum database clean --dry-run` | `EXECUTE /database/clean` with `{ dryRun: true }`                   |
+| `simulacrum --help database clean`    | `HELP /database/clean`; controls target the deepest selected route  |
+| `simulacrum database`                 | `method-not-allowed`; `/database` does not support execution        |
+| `simulacrum serve --port nope`        | `unprocessable-content`; invalid data never reaches the application |
 
-## Add commands, keep dispatch flat
+Command literals are routing tokens, not positional arguments. Configliere
+selects the route first, then binds options to the route segment that owns them.
+This makes identical option names on parent and child routes unambiguous.
 
-Routes form a tree, but callers do not have to mirror that tree with nested
-conditionals. `IntentsOf<typeof app>` is a flat union of every method and route
-the definition can reach, so `result.route` is another useful discriminant.
+## Marshal configuration into the route
+
+CLI arguments are only one source. Configliere can marshal JavaScript values and
+flat environment records into the same route-local models:
+
+```ts
+const result = parse(app, {
+  argv: process.argv.slice(2),
+  values: [{
+    name: "config.json",
+    value: { serve: { port: 4200 } },
+  }],
+  envs: [{
+    name: "process",
+    value: process.env,
+  }],
+});
+```
+
+For `/serve`, `serve.port` and `SERVE_PORT` both address its `port` parameter.
+CLI text and environment text are decoded; JavaScript values are used directly.
+The resulting value is then validated by its
+[Standard Schema](https://standardschema.dev/) schema. Zod, ArkType, Valibot,
+and other conforming libraries work without adapters.
+
+Source precedence is explicit:
+
+```text
+CLI → environment → JavaScript values → schema default
+```
+
+## Pause without surrendering the type system
+
+Sometimes the route cannot be fully configured—or even fully discovered—until
+the application performs I/O. Configliere can pause at a typed checkpoint and
+resume with the result:
 
 ```ts
 import process from "node:process";
 import {
+  checkpoint,
   command,
   name,
   option,
   parse,
-  printHelp,
-  routes,
+  type Result,
   schema,
-  toggle,
+  type ValueSource,
 } from "@frontside/configliere";
-import { type } from "arktype";
+import * as z from "zod";
 
 const app = command(
-  name("simulacrum"),
-  toggle(name("verbose")),
-  routes(
-    command(
-      name("serve"),
-      option(name("port"), schema(type("number"))),
-    ),
-    command(
-      name("inspect"),
-      toggle(name("json")),
-    ),
-  ),
+  name("server"),
+  option(name("config"), schema(z.string())),
+  checkpoint(),
+  option(name("port"), schema(z.number())),
 );
 
-const result = parse(app, { argv: process.argv.slice(2) });
+const step = parse(app, { argv: process.argv.slice(2) });
 
-if (!result.ok) {
-  console.error(result.code, result);
+if (!step.ok) {
   process.exit(1);
 }
 
-if (result.method === "help") {
-  console.log(printHelp(result));
-} else {
-  switch (result.route) {
-    case "/":
-      // model:  { verbose: boolean }
-      // models: { "/": { verbose: boolean } }
-      start(result.model);
-      break;
+step.model.config; // string—the model resolved before the checkpoint
 
-    case "/serve":
-      // model is only the selected route's model.
-      result.model.port; // number
+const loaded = await load(step.model.config);
+const result = step.resume(loaded);
 
-      // models contains every model on the matched route lineage.
-      result.models["/"].verbose; // boolean
-      result.models["/serve"].port; // number
-
-      // @ts-expect-error: /inspect was not part of this match.
-      result.models["/inspect"];
-      serve(result.model, result.models["/"]);
-      break;
-
-    case "/inspect":
-      // model:  { json: boolean }
-      // models: { "/": { verbose: boolean }, "/inspect": { json: boolean } }
-      inspect(result.model, result.models["/"]);
-      break;
-  }
+if (result.ok && result.method === "execute") {
+  result.model; // { config: string; port: number }
 }
 
-function start(model: { verbose: boolean }): void {
-  console.log(`simulacrum; verbose=${model.verbose}`);
-}
-
-function serve(
-  model: { port: number },
-  root: { verbose: boolean },
-): void {
-  console.log(`serving on ${model.port}; verbose=${root.verbose}`);
-}
-
-function inspect(
-  model: { json: boolean },
-  root: { verbose: boolean },
-): void {
-  console.log(`inspecting; json=${model.json}; verbose=${root.verbose}`);
-}
+declare function load(path: string): Promise<Result<ValueSource[]>>;
 ```
 
-| Invocation                               | Result                                                                                               |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `simulacrum --verbose`                   | `EXECUTE /`; `model` and `models["/"]` are `{ verbose: true }`                                       |
-| `simulacrum --verbose serve --port 4000` | `EXECUTE /serve`; `model` is `{ port: 4000 }`, while `models` also contains `"/": { verbose: true }` |
-| `simulacrum inspect --json`              | `EXECUTE /inspect`; `model` is `{ json: true }` and the root model has `{ verbose: false }`          |
-| `simulacrum serve --help`                | `HELP /serve`; no root or command model is validated                                                 |
+The parser remains synchronous and performs no I/O. The caller loads the file
+and resumes with a `Result`; loader failures enter the ordinary issue path.
+Unconsumed CLI input survives the pause, so a later `--port 5000` can override
+the value loaded from the file.
 
-Route tokens select the deepest matching route; they are not positional
-arguments. Options on each segment bind only to the model owned by that route.
-The root definition's name identifies the executable but is not repeated in
-route IDs: the root is `/`, not `/simulacrum`.
-
-For a deeper route such as `/database/clean`, the same rule applies:
-`result.model` is the clean command's model, while `result.models` has exact
-entries for `/`, `/database`, and `/database/clean`. Sibling models are absent
-at runtime and from the TypeScript type.
+The same phase mechanism can add options or routes from runtime data. Parsing
+then continues against the expanded route graph, and the continuation type
+describes the entry points that can appear next.

--- a/docs/binding.md
+++ b/docs/binding.md
@@ -3,19 +3,19 @@
 `bindPhase()` is a source scheduler, not a source interpreter.
 
 CLI, Values, and Env all attempt to supply values for parameters, but they do
-not traverse their inputs in the same way. CLI is positional: its safely
-visible input can grow as options and arguments consume words. Values and Env
-are address sources: once the route and parameter address are known, their
+not traverse their inputs in the same way. CLI is positional: its safely visible
+input can grow as options and arguments consume words. Values and Env are
+address sources: once the route and parameter address are known, their
 visibility is stable.
 
-The binding algorithm should preserve that distinction while giving every
-source the same attempt protocol. The intended precedence is visible directly
-in its structure:
+The binding algorithm should preserve that distinction while giving every source
+the same attempt protocol. The intended precedence is visible directly in its
+structure:
 
 ```text
 CLI fixed point
-Values
 Env
+Values
 undefined
 ```
 
@@ -55,8 +55,8 @@ The outcomes mean:
   are blocked.
 
 A malformed CLI option is therefore an existing, failed attempt because it
-claimed input. A decoding or schema error from a higher-priority source must
-not disappear by silently selecting a lower-priority value.
+claimed input. A decoding or schema error from a higher-priority source must not
+disappear by silently selecting a lower-priority value.
 
 Explicit `undefined` from a JavaScript value source is also present. It must be
 distinguished from an absent property, must shadow lower-priority sources, and
@@ -88,10 +88,10 @@ The **horizon** is the first remaining word in the current route segment. It is
 the inclusive boundary of safe lookahead. This is not a cursor: it does not
 identify the current consumption position.
 
-The horizon itself must be visible so an option or positional argument can
-prove that the word is data by claiming it. The entire suffix after it remains
-hidden because, if the horizon becomes a child selector, every following
-option belongs to that child.
+The horizon itself must be visible so an option or positional argument can prove
+that the word is data by claiming it. The entire suffix after it remains hidden
+because, if the horizon becomes a child selector, every following option belongs
+to that child.
 
 ### Dynamic route discovery
 
@@ -118,8 +118,8 @@ view:                    [---] |--- hidden ---|
 ```
 
 Nothing in the current phase claims `auth0`, so the horizon remains unchanged
-after a complete parameter sweep. CLI binding has reached a fixed point and
-must stop.
+after a complete parameter sweep. CLI binding has reached a fixed point and must
+stop.
 
 If `resume()` introduces an `auth0` route, route search can now claim index 2 as
 its selector. The child receives `--port 9001`. Without the horizon, a parent
@@ -157,8 +157,8 @@ moves to `auth0`:
                                horizon
 ```
 
-No parameter claims it, so the horizon is stable and CLI binding stops. This
-is a fixed-point calculation rather than an ordinary left-to-right cursor.
+No parameter claims it, so the horizon is stable and CLI binding stops. This is
+a fixed-point calculation rather than an ordinary left-to-right cursor.
 
 Route search always runs before phase binding. A currently discoverable route
 therefore beats an option value. A route introduced only after the current
@@ -168,9 +168,9 @@ the unambiguous escape hatch.
 
 ## Tokenizer support
 
-There is one global tokenizer and one global claim ledger for a parse. A
-binding phase needs borrowed, bounded views into that tokenizer rather than
-temporary tokenizers whose claims later have to be reconstructed.
+There is one global tokenizer and one global claim ledger for a parse. A binding
+phase needs borrowed, bounded views into that tokenizer rather than temporary
+tokenizers whose claims later have to be reconstructed.
 
 The central addition is a first-class view:
 
@@ -189,19 +189,18 @@ class Tokenizer<T> implements TokenInput<T> {
 }
 ```
 
-A view changes visibility only. It never owns claims. Every claim made
-through a view returns a remainder rooted in the global tokenizer. As a
-result, `bindPhase()` can propagate the returned tokenizer directly and never
-needs to:
+A view changes visibility only. It never owns claims. Every claim made through a
+view returns a remainder rooted in the global tokenizer. As a result,
+`bindPhase()` can propagate the returned tokenizer directly and never needs to:
 
 1. Materialize the visible tokens.
 2. Compare them with a temporary remainder.
 3. Recover the claimed indices.
 4. Replay those claims against the global tokenizer.
 
-The tokenizer should materialize one stable token array and carry one
-cumulative immutable set of claimed indices. Claims should not create an
-ever-deepening stack of tokenizer iterators.
+The tokenizer should materialize one stable token array and carry one cumulative
+immutable set of claimed indices. Claims should not create an ever-deepening
+stack of tokenizer iterators.
 
 The remaining invariants are:
 
@@ -218,7 +217,7 @@ existing segment start and end can therefore become a real range:
 ```ts
 interface TokenRange {
   readonly start: number; // exclusive
-  readonly end?: number;  // exclusive
+  readonly end?: number; // exclusive
 }
 ```
 
@@ -272,13 +271,16 @@ function bindPhase(options: BindPhaseOptions): PhaseBinding {
   }
 
   // Stable address sources: array order is precedence.
-  for (let source of [fromValues, fromEnv]) {
+  for (let source of [fromEnv, fromValues]) {
     for (let param of pending.values()) {
-      accept(param, source({
+      accept(
         param,
-        route: segment.path,
-        rest,
-      }));
+        source({
+          param,
+          route: segment.path,
+          rest,
+        }),
+      );
     }
   }
 
@@ -305,8 +307,8 @@ no remaining words before or after it, the next comparison terminates.
 
 ## Parser integration
 
-A phase owns the introduction of its value and environment sources; parser
-state owns their lifetime after introduction.
+A phase owns the introduction of its value and environment sources; parser state
+owns their lifetime after introduction.
 
 When a phase becomes active, mount its newly declared sources at the current
 route path:
@@ -319,10 +321,10 @@ rest = {
 };
 ```
 
-Those sources remain available to every downstream phase. Input-level Values
-and Env sources are mounted at `/` before the first phase. Sources introduced
-on a child route are mounted at that child's route path. Sources introduced by
-a dynamic continuation become visible only after that continuation is resumed.
+Those sources remain available to every downstream phase. Input-level Values and
+Env sources are mounted at `/` before the first phase. Sources introduced on a
+child route are mounted at that child's route path. Sources introduced by a
+dynamic continuation become visible only after that continuation is resumed.
 
 Parser state should carry `rest` as one value and replace it wholesale with the
 phase result:
@@ -352,9 +354,9 @@ The design should be established with observable tests for these cases:
   parameters.
 - A stable horizon leaves the entire suffix untouched.
 - CLI overrides Values even when its option is not visible until a later sweep.
-- Values override Env when that is the declared source order.
-- Invalid CLI blocks valid Values and Env.
-- Invalid Values block valid Env.
+- Env overrides Values when that is the declared source order.
+- Invalid CLI blocks valid Env and Values.
+- Invalid Env blocks valid Values.
 - Only total absence invokes required, optional, or defaulting schema behavior.
 - A dynamically introduced child receives every token after its selector.
 - Sources introduced by a phase become available at that phase and persist

--- a/lib/bind.ts
+++ b/lib/bind.ts
@@ -96,6 +96,36 @@ export function fromValues<const K extends string, T>(options: {
   };
 }
 
+export function fromEnv<const K extends string, T>(options: {
+  readonly param: Param<K, T>;
+  readonly route: Path;
+  readonly rest: Rest;
+}): Maybe<Binding<T>> {
+  let { param, route, rest } = options;
+  let claim = rest.envs.claim({
+    route,
+    address: [param.name],
+    key: param.env,
+  });
+
+  if (!claim.result.exists) {
+    return { exists: false };
+  }
+
+  let value = claim.result.value.value;
+
+  return {
+    exists: true,
+    value: {
+      rest: {
+        ...rest,
+        envs: claim.rest,
+      },
+      result: decode(param, value, param.decode(value), [param.name]),
+    },
+  };
+}
+
 export function bindPhase(options: {
   readonly phase: AnyPhase;
   readonly segment: PhaseSegment;
@@ -148,7 +178,7 @@ export function bindPhase(options: {
   // Address sources have stable visibility once the route is known. They are
   // tried only after CLI has reached its fixed point so a provisional CLI miss
   // cannot let a lower-priority source settle the parameter too early.
-  for (let source of [fromValues]) {
+  for (let source of [fromEnv, fromValues]) {
     for (let param of pending.values()) {
       accept(
         param,

--- a/lib/decode.ts
+++ b/lib/decode.ts
@@ -13,4 +13,14 @@ export const scalar: Decoder = (value) => {
   return [...number(value), value];
 };
 
+export const boolean: Decoder = (value) => {
+  if (value === "true") {
+    return [true];
+  }
+  if (value === "false") {
+    return [false];
+  }
+  return [];
+};
+
 const numeric = /^-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?$/;

--- a/lib/dynamic.ts
+++ b/lib/dynamic.ts
@@ -28,6 +28,7 @@ export function dynamic<
       params: {},
       routes: [],
       values: [],
+      envs: [],
     });
 
     return { ...route, phases } as unknown as Conjoin<

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,137 @@
+import type { Maybe } from "./maybe.ts";
+import type { Param } from "./param.ts";
+import type { AnyRoute, RoutePath } from "./types.ts";
+
+export interface EnvSource {
+  readonly name: string;
+  readonly value: Environment;
+}
+
+export type Environment = Readonly<Record<string, string | undefined>>;
+
+export interface EnvClaim {
+  readonly result: Maybe<{
+    readonly source: string;
+    readonly address: readonly string[];
+    readonly key: string;
+    readonly value: string;
+  }>;
+  readonly rest: Envs;
+}
+
+export interface EnvClaimOptions {
+  readonly route: readonly string[];
+  readonly address: readonly string[];
+  readonly key?: string;
+}
+
+export function env(
+  key: string,
+): <P extends Param<string, unknown>>(param: P) => P {
+  return (param) => ({ ...param, env: key });
+}
+
+export function withEnvs(
+  envs: readonly EnvSource[],
+): <R extends AnyRoute>(route: R) => R {
+  return (route) => {
+    let phases = [...route.phases];
+    let phase = phases.pop()!;
+    phases.push({
+      ...phase,
+      envs: phase.envs.concat(envs),
+    });
+    return {
+      ...route,
+      phases,
+    };
+  };
+}
+
+export class Envs {
+  mounts: Map<RoutePath, EnvSource[]>;
+  claims: Set<ClaimId>;
+
+  constructor(
+    mounts: Map<RoutePath, EnvSource[]> = new Map(),
+    claims: Set<ClaimId> = new Set(),
+  ) {
+    this.mounts = mounts;
+    this.claims = claims;
+  }
+
+  mount(path: readonly string[], sources: readonly EnvSource[]): Envs {
+    if (sources.length === 0) {
+      return this;
+    }
+    let id = routeId(path);
+
+    return new Envs(
+      new Map([...this.mounts.entries(), [
+        id,
+        (this.mounts.get(id) ?? []).concat(sources),
+      ]]),
+      this.claims,
+    );
+  }
+
+  claim(
+    { route, address, key = envKey([...route, ...address]) }: EnvClaimOptions,
+  ): EnvClaim {
+    let id = claimId([...route, ...address]);
+    let nope: EnvClaim = { result: { exists: false }, rest: this };
+    if (this.claims.has(id)) {
+      return nope;
+    }
+
+    for (let end = route.length; end >= 0; end--) {
+      let mount = routeId(route.slice(0, end));
+      let sources = this.mounts.get(mount) ?? [];
+
+      for (let { name, value } of sources) {
+        if (!Object.hasOwn(value, key) || typeof value[key] === "undefined") {
+          continue;
+        }
+
+        let rest = new Envs(this.mounts, new Set([...this.claims, id]));
+        return {
+          result: {
+            exists: true,
+            value: {
+              source: name,
+              address,
+              key,
+              value: value[key],
+            },
+          },
+          rest,
+        };
+      }
+    }
+
+    return nope;
+  }
+}
+
+type ClaimId = string;
+
+function routeId(path: readonly string[]): RoutePath {
+  return `/${path.join("/")}`;
+}
+
+function claimId(address: readonly string[]): ClaimId {
+  return JSON.stringify(address);
+}
+
+function envKey(address: readonly string[]): string {
+  return address.map(normalize).filter(Boolean).join("_");
+}
+
+function normalize(value: string): string {
+  return value
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1_$2")
+    .replace(/([a-z\d])([A-Z])/g, "$1_$2")
+    .replace(/[^A-Za-z\d]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .toUpperCase();
+}

--- a/lib/option.ts
+++ b/lib/option.ts
@@ -1,7 +1,14 @@
 import { extend } from "./extend.ts";
 import { type Param, param } from "./param.ts";
 import { cli } from "./read.ts";
-import type { AddParamToLast, AnyPhases, AnyRoute, Definition, Method, Route } from "./types.ts";
+import type {
+  AddParamToLast,
+  AnyPhases,
+  AnyRoute,
+  Definition,
+  Method,
+  Route,
+} from "./types.ts";
 
 export function option<const N extends string>(
   named: Definition<N>,
@@ -139,7 +146,7 @@ type Option<K extends string, V> = <
   const M extends Method,
   const T extends object,
   const C extends readonly AnyRoute[],
-  const P extends AnyPhases
+  const P extends AnyPhases,
 >(
   route: Route<N, M, T, C, P>,
 ) => Route<

--- a/lib/param.ts
+++ b/lib/param.ts
@@ -9,6 +9,7 @@ export interface Param<K extends string, T> extends Definition<K> {
   schema: Schema<T>;
   cli: ReadCLI;
   decode: Decoder;
+  env?: string;
 }
 
 export function param<const K extends string>(

--- a/lib/parse.ts
+++ b/lib/parse.ts
@@ -1,4 +1,5 @@
 import { bindPhase } from "./bind.ts";
+import { Envs } from "./env.ts";
 import type { Symbol } from "./read.ts";
 import type { Rest } from "./rest.ts";
 import type { Result } from "./result.ts";
@@ -47,6 +48,7 @@ export function parse(
   let rest: Rest = {
     tokens: literals.rest as Tokenizer<Symbol>,
     values: new Values().mount([], input.values ?? []),
+    envs: new Envs().mount([], input.envs ?? []),
   };
 
   return resume({
@@ -85,6 +87,7 @@ function resume(
       rest: {
         ...state.rest,
         values: state.rest.values.mount(segment.path, phase.values),
+        envs: state.rest.envs.mount(segment.path, phase.envs),
       },
     };
 
@@ -351,6 +354,10 @@ function stitch(
       ...phase.values,
       ...next.values,
     ],
+    envs: [
+      ...phase.envs,
+      ...next.envs,
+    ],
   });
   phases.push(...rest);
 
@@ -415,6 +422,7 @@ function seed(route: AnyRoute): AnyRoute {
       params: {},
       routes: [],
       values: [],
+      envs: [],
     }],
   };
 }

--- a/lib/rest.ts
+++ b/lib/rest.ts
@@ -1,3 +1,4 @@
+import type { Envs } from "./env.ts";
 import type { Symbol } from "./read.ts";
 import type { Tokenizer } from "./tokenizer.ts";
 import type { Values } from "./values.ts";
@@ -5,4 +6,5 @@ import type { Values } from "./values.ts";
 export interface Rest {
   readonly tokens: Tokenizer<Symbol>;
   readonly values: Values;
+  readonly envs: Envs;
 }

--- a/lib/route.ts
+++ b/lib/route.ts
@@ -1113,6 +1113,7 @@ export function route(
       params: {},
       routes: [],
       values: [],
+      envs: [],
     }],
   };
   return extend(elements)(zero);

--- a/lib/toggle.ts
+++ b/lib/toggle.ts
@@ -1,7 +1,16 @@
+import { boolean as decode } from "./decode.ts";
 import { type Param, param, schema } from "./param.ts";
 import type { CLIRead, ReadCLI } from "./read.ts";
 import type { Flag } from "./tokenize.ts";
-import type { AddParamToLast, AnyPhases, AnyRoute, Definition, Method, Route, Schema } from "./types.ts";
+import type {
+  AddParamToLast,
+  AnyPhases,
+  AnyRoute,
+  Definition,
+  Method,
+  Route,
+  Schema,
+} from "./types.ts";
 
 export function toggle<const N extends string>(
   named: Definition<N>,
@@ -115,7 +124,10 @@ export function toggle(
 ): unknown {
   const added = elements.reduce<unknown>(
     (value, element) => element(value as never),
-    param(named, binding(named.name), schema(bool)),
+    {
+      ...param(named, binding(named.name), schema(bool)),
+      decode,
+    },
   ) as Param<string, unknown>;
 
   return (route: AnyRoute) => {
@@ -141,7 +153,7 @@ type Toggle<K extends string, V> = <
   const M extends Method,
   const T extends object,
   const C extends readonly AnyRoute[],
-  const P extends AnyPhases
+  const P extends AnyPhases,
 >(
   route: Route<N, M, T, C, P>,
 ) => Route<

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,4 +1,5 @@
 import type { StandardSchemaV1 } from "@standard-schema/spec";
+import type { EnvSource } from "./env.ts";
 import type { Literal } from "./tokenize.ts";
 import type { Param } from "./param.ts";
 import type { Result } from "./result.ts";
@@ -43,6 +44,7 @@ export type Next<
   readonly params: Params<Model>;
   readonly routes: Routes;
   readonly values: readonly ValueSource[];
+  readonly envs: readonly EnvSource[];
   readonly resolver: (
     requirement: T,
   ) => (input: AnyRoute) => AnyRoute;
@@ -55,6 +57,7 @@ export type Done<
   readonly params: Params<Model>;
   readonly routes: Routes;
   readonly values: readonly ValueSource[];
+  readonly envs: readonly EnvSource[];
 };
 
 export type Params<Model extends object> = {
@@ -121,6 +124,7 @@ export interface AnyPhase {
   readonly params: Params<object>;
   readonly routes: readonly AnyRoute[];
   readonly values: readonly ValueSource[];
+  readonly envs: readonly EnvSource[];
   readonly resolver?: (requirement: never) => (route: never) => AnyRoute;
 }
 
@@ -134,6 +138,7 @@ export type Path = readonly string[];
 export type Input = {
   argv: string[];
   values?: readonly ValueSource[];
+  envs?: readonly EnvSource[];
 };
 
 export interface Failure<C extends Status> {

--- a/mod.ts
+++ b/mod.ts
@@ -6,6 +6,9 @@ export { checkpoint } from "./lib/checkpoint.ts";
 
 export { description, name } from "./lib/definition.ts";
 
+export { env, withEnvs } from "./lib/env.ts";
+export type { Environment, EnvSource } from "./lib/env.ts";
+
 export { option } from "./lib/option.ts";
 
 export { param, schema } from "./lib/param.ts";

--- a/test/bind.test.ts
+++ b/test/bind.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "@std/testing/bdd";
 import * as z from "zod";
 import { type Binding, bindPhase, fromCLI } from "../lib/bind.ts";
 import { name } from "../lib/definition.ts";
+import { Envs } from "../lib/env.ts";
 import type { Maybe } from "../lib/maybe.ts";
 import { type Param, param, schema } from "../lib/param.ts";
 import { cli, type Symbol } from "../lib/read.ts";
@@ -161,6 +162,7 @@ describe("binding", () => {
     let rest: Rest = {
       tokens: symbols(["--port", "9001"]),
       values,
+      envs: new Envs(),
     };
     let attempt = fromCLI({
       param: param(
@@ -270,6 +272,7 @@ function state(argv: string[]): Rest {
   return {
     tokens: symbols(argv),
     values: new Values(),
+    envs: new Envs(),
   };
 }
 
@@ -278,6 +281,7 @@ function phase(params: Record<string, Param<string, unknown>>) {
     params,
     routes: [],
     values: [],
+    envs: [],
   };
 }
 

--- a/test/decode.test.ts
+++ b/test/decode.test.ts
@@ -1,6 +1,6 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
-import { number, scalar } from "../lib/decode.ts";
+import { boolean, number, scalar } from "../lib/decode.ts";
 
 describe("decoders", () => {
   it("offers numeric and text interpretations of a numeral", () => {
@@ -9,5 +9,11 @@ describe("decoders", () => {
 
   it("returns no candidate when a number cannot be decoded", () => {
     expect(number("twelve")).toEqual([]);
+  });
+
+  it("decodes boolean text without treating other text as boolean", () => {
+    expect(boolean("true")).toEqual([true]);
+    expect(boolean("false")).toEqual([false]);
+    expect(boolean("yes")).toEqual([]);
   });
 });

--- a/test/dynamic.test.ts
+++ b/test/dynamic.test.ts
@@ -749,30 +749,6 @@ Options:
         });
       });
     });
-
-    describe("future sources", () => {
-      it.skip("lets a later phase claim an existing environment source", () => {
-        // let app = command(
-        //   name("simulacrum"),
-        //   dynamic((_config: Config) =>
-        //     extend(option(name("b"), env("B")))
-        //   ),
-        // );
-        // let first = parse(app, {
-        //   argv: [],
-        //   envs: [{ name: "process", value: { B: "two" } }],
-        // });
-        // increment(first, {});
-        // let result = first.resume({
-        //   ok: true,
-        //   value: { services: [] },
-        // });
-        // expect(result).toMatchObject({
-        //   method: "execute",
-        //   model: { b: "two" },
-        // });
-      });
-    });
   });
 });
 

--- a/test/env.test.ts
+++ b/test/env.test.ts
@@ -1,0 +1,730 @@
+import { expect } from "@std/expect";
+import { describe, it } from "@std/testing/bdd";
+import * as z from "zod";
+import { command } from "../lib/command.ts";
+import { name } from "../lib/definition.ts";
+import { dynamic } from "../lib/dynamic.ts";
+import { env, withEnvs } from "../lib/env.ts";
+import { extend } from "../lib/extend.ts";
+import { option } from "../lib/option.ts";
+import { schema } from "../lib/param.ts";
+import { parse } from "../lib/parse.ts";
+import { route, routes } from "../lib/route.ts";
+import { toggle } from "../lib/toggle.ts";
+import type { ModelOf } from "../lib/types.ts";
+
+describe("environment binding", () => {
+  describe("mapping", () => {
+    it("maps a root parameter to its normalized environment name", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { PORT: "9001" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: { port: 9001 },
+      });
+    });
+
+    it("prefixes a parameter with its complete route path", () => {
+      let clean = command(
+        name("clean"),
+        option(name("dryRun"), schema(z.string())),
+      );
+      let database = route(name("database"), routes(clean));
+      let app = command(name("simulacrum"), routes(database));
+      let result = parse(app, {
+        argv: ["database", "clean"],
+        envs: [{
+          name: "process",
+          value: { DATABASE_CLEAN_DRY_RUN: "yes" },
+        }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/database/clean",
+        model: { dryRun: "yes" },
+      });
+    });
+
+    it("normalizes acronyms and punctuation", () => {
+      let clean = command(
+        name("pg:clean"),
+        option(name("clientID"), schema(z.string())),
+      );
+      let app = command(name("simulacrum"), routes(clean));
+      let result = parse(app, {
+        argv: ["pg:clean"],
+        envs: [{
+          name: "process",
+          value: { PG_CLEAN_CLIENT_ID: "0012" },
+        }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/pg:clean",
+        model: { clientID: "0012" },
+      });
+    });
+
+    it("lets an explicit environment mapping replace the default", () => {
+      let app = command(
+        name("simulacrum"),
+        option(
+          name("port"),
+          env("HTTP_PORT"),
+          schema(z.number()),
+        ),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{
+          name: "process",
+          value: { PORT: "9001", HTTP_PORT: "9002" },
+        }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: { port: 9002 },
+      });
+    });
+
+    it("does not retain the inferred environment name as an alias", () => {
+      let app = command(
+        name("simulacrum"),
+        option(
+          name("port"),
+          schema(z.number()),
+          env("HTTP_PORT"),
+        ),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { PORT: "9001" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ path: ["port"] }],
+      });
+    });
+
+    it("does not change the inferred model type", () => {
+      let app = command(
+        name("simulacrum"),
+        option(
+          name("port"),
+          env("HTTP_PORT"),
+          schema(z.number()),
+        ),
+      );
+
+      expectType<Equal<ModelOf<typeof app>, { port: number }>>(true);
+    });
+  });
+
+  describe("decoding", () => {
+    it("decodes environment text with the parameter decoder", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { PORT: "9001" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { port: 9001 },
+      });
+    });
+
+    it("tries later decoder candidates", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("clientID"), schema(z.string())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { CLIENT_ID: "0012" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { clientID: "0012" },
+      });
+    });
+
+    it("reports schema issues for an invalid decoded value", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { PORT: "nope" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ path: ["port"] }],
+      });
+    });
+
+    it("treats an empty string as present", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("domain"), schema(z.string().default("localhost"))),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { DOMAIN: "" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { domain: "" },
+      });
+    });
+
+    it("decodes environment text for a toggle", () => {
+      let app = command(
+        name("simulacrum"),
+        toggle(name("verbose")),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { VERBOSE: "true" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { verbose: true },
+      });
+    });
+  });
+
+  describe("absence", () => {
+    it("validates undefined when no source contains the key", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: {} }],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ path: ["port"] }],
+      });
+    });
+
+    it("lets an absent environment value activate a schema default", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number().default(9000))),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: {} }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { port: 9000 },
+      });
+    });
+
+    it("treats an undefined process environment entry as absent", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [
+          { name: "process", value: { PORT: undefined } },
+          { name: "defaults", value: { PORT: "9001" } },
+        ],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { port: 9001 },
+      });
+    });
+  });
+
+  describe("precedence", () => {
+    it("prefers CLI over environment values", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: ["--port", "9002"],
+        envs: [{ name: "process", value: { PORT: "nope" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { port: 9002 },
+        issues: [],
+      });
+    });
+
+    it("prefers environment values over JavaScript values", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        values: [{ name: "settings", value: { port: 9002 } }],
+        envs: [{ name: "process", value: { PORT: "9001" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { port: 9001 },
+        issues: [],
+      });
+    });
+
+    it("does not hide an invalid environment value with a JavaScript value", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        values: [{ name: "settings", value: { port: 9002 } }],
+        envs: [{ name: "process", value: { PORT: "nope" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ path: ["port"] }],
+      });
+    });
+
+    it("does not hide an incomplete CLI option with an environment value", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: ["--port"],
+        envs: [{ name: "process", value: { PORT: "9001" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ message: "--port requires a value" }],
+      });
+    });
+
+    it("uses the first environment source containing the key", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [
+          { name: "settings", value: { PORT: "9001" } },
+          { name: "defaults", value: { PORT: "9002" } },
+        ],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { port: 9001 },
+      });
+    });
+
+    it("tries the next environment source when the key is absent", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [
+          { name: "settings", value: { HOST: "localhost" } },
+          { name: "defaults", value: { PORT: "9002" } },
+        ],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { port: 9002 },
+      });
+    });
+
+    it("does not hide an invalid environment value with a later source", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [
+          { name: "settings", value: { PORT: "nope" } },
+          { name: "defaults", value: { PORT: "9002" } },
+        ],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ path: ["port"] }],
+      });
+    });
+
+    it("does not replace an invalid environment value with a default", () => {
+      let app = command(
+        name("simulacrum"),
+        option(name("port"), schema(z.number().default(9000))),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { PORT: "nope" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ path: ["port"] }],
+      });
+    });
+  });
+
+  describe("mounting", () => {
+    it("binds sources introduced by withEnvs()", () => {
+      let app = command(
+        name("simulacrum"),
+        withEnvs([{
+          name: "defaults",
+          value: { PORT: "9001" },
+        }]),
+        option(name("port"), schema(z.number())),
+      );
+      let result = parse(app, { argv: [] });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: { port: 9001 },
+      });
+    });
+
+    it("prefers a source mounted on the current route over an ancestor", () => {
+      let auth0 = command(
+        name("auth0"),
+        withEnvs([{
+          name: "auth0.json",
+          value: { AUTH0_PORT: "9003" },
+        }]),
+        option(name("port"), schema(z.number())),
+      );
+      let app = command(
+        name("simulacrum"),
+        withEnvs([{
+          name: "settings",
+          value: { AUTH0_PORT: "9001" },
+        }]),
+        routes(auth0),
+      );
+      let result = parse(app, { argv: ["auth0"] });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/auth0",
+        model: { port: 9003 },
+      });
+    });
+
+    it("falls back to an ancestor source when the local key is absent", () => {
+      let auth0 = command(
+        name("auth0"),
+        withEnvs([{
+          name: "auth0.json",
+          value: { AUTH0_DOMAIN: "auth0.local" },
+        }]),
+        option(name("port"), schema(z.number())),
+      );
+      let app = command(
+        name("simulacrum"),
+        withEnvs([{
+          name: "settings",
+          value: { AUTH0_PORT: "9001" },
+        }]),
+        routes(auth0),
+      );
+      let result = parse(app, { argv: ["auth0"] });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/auth0",
+        model: { port: 9001 },
+      });
+    });
+
+    it("lets distinct target addresses read the same environment key", () => {
+      let auth0 = command(
+        name("auth0"),
+        option(
+          name("secondary"),
+          env("PORT"),
+          schema(z.number()),
+        ),
+      );
+      let app = command(
+        name("simulacrum"),
+        option(
+          name("primary"),
+          env("PORT"),
+          schema(z.number()),
+        ),
+        routes(auth0),
+      );
+      let result = parse(app, {
+        argv: ["auth0"],
+        envs: [{ name: "process", value: { PORT: "9001" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/auth0",
+        models: {
+          "/": { primary: 9001 },
+          "/auth0": { secondary: 9001 },
+        },
+      });
+    });
+
+    it("ignores unconsumed environment keys", () => {
+      let app = command(name("simulacrum"));
+      let result = parse(app, {
+        argv: [],
+        envs: [{
+          name: "process",
+          value: { UNRELATED: "value" },
+        }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: {},
+      });
+    });
+  });
+
+  describe("dynamic phases", () => {
+    it("keeps input environment sources available to later parameters", () => {
+      let app = command(
+        name("simulacrum"),
+        dynamic((_plugins: Plugins) =>
+          extend(
+            option(name("domain"), schema(z.string())),
+          )
+        ),
+      );
+      let increment = parse(app, {
+        argv: [],
+        envs: [{
+          name: "process",
+          value: { DOMAIN: "auth0.local" },
+        }],
+      });
+
+      assertIncrement(increment);
+      let result = increment.resume({
+        ok: true,
+        value: { names: ["auth0"] },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: { domain: "auth0.local" },
+      });
+    });
+
+    it("uses the final path when mapping a dynamically introduced route", () => {
+      let auth0 = command(
+        name("auth0"),
+        option(name("port"), schema(z.number())),
+      );
+      let app = command(
+        name("simulacrum"),
+        dynamic((_plugins: Plugins) => extend(routes(auth0))),
+      );
+      let increment = parse(app, {
+        argv: ["auth0"],
+        envs: [{
+          name: "process",
+          value: { AUTH0_PORT: "9001" },
+        }],
+      });
+
+      assertIncrement(increment);
+      let result = increment.resume({
+        ok: true,
+        value: { names: ["auth0"] },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/auth0",
+        model: { port: 9001 },
+      });
+    });
+
+    it("keeps dynamically introduced environment sources available downstream", () => {
+      let app = command(
+        name("simulacrum"),
+        dynamic((_plugins: Plugins) =>
+          extend(
+            withEnvs([{
+              name: "settings",
+              value: { DOMAIN: "auth0.local" },
+            }]),
+            dynamic((_services: Plugins) =>
+              extend(
+                option(name("domain"), schema(z.string())),
+              )
+            ),
+          )
+        ),
+      );
+      let first = parse(app, { argv: [] });
+
+      assertIncrement(first);
+      let second = first.resume({
+        ok: true,
+        value: { names: ["config"] },
+      });
+
+      assertIncrement(second);
+      let result = second.resume({
+        ok: true,
+        value: { names: ["auth0"] },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: { domain: "auth0.local" },
+      });
+    });
+
+    it("binds environment input needed to discover a help route", () => {
+      let auth0 = command(name("auth0"));
+      let app = command(
+        name("simulacrum"),
+        option(name("config"), schema(z.string())),
+        dynamic((_plugins: Plugins) => extend(routes(auth0))),
+      );
+      let increment = parse(app, {
+        argv: ["auth0", "--help"],
+        envs: [{
+          name: "process",
+          value: { CONFIG: "plugins.json" },
+        }],
+      });
+
+      assertIncrement(increment, { config: "plugins.json" });
+      let result = increment.resume({
+        ok: true,
+        value: { names: ["auth0"] },
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "help",
+        route: "/auth0",
+      });
+    });
+  });
+});
+
+interface Plugins {
+  readonly names: readonly string[];
+}
+
+type Equal<L, R> = (<T>() => T extends L ? 1 : 2) extends
+  (<T>() => T extends R ? 1 : 2)
+  ? (<T>() => T extends R ? 1 : 2) extends (<T>() => T extends L ? 1 : 2) ? true
+  : false
+  : false;
+
+function expectType<T extends true>(_value: T): void {
+  // Compile-time assertion.
+}
+
+function assertIncrement<T>(
+  result: T,
+  model: object = {},
+): asserts result is Extract<
+  T,
+  { readonly ok: true; readonly resume: unknown }
+> {
+  expect(result).toMatchObject({
+    ok: true,
+    route: "/",
+    model,
+  });
+  expect(
+    typeof (result as { readonly resume?: unknown }).resume,
+  ).toBe("function");
+}


### PR DESCRIPTION
## Stack

- Root: #20
- Dynamic phases: #22
- Source-aware binding: #23
- This PR: environment sources (position 4)

## Direction

This layer will add environment variables as another named, route-mounted binding source without changing phase scheduling.

The intended precedence remains explicit:

1. CLI reaches its positional fixed point.
2. JavaScript value sources are consulted.
3. Environment sources are consulted.
4. Total absence is validated as undefined.

Environment readers capture strings and use parameter decoders before schema validation. An invalid selected environment value must settle the parameter and block lower-priority fallback, just like every other binding source.

This draft begins with an empty checkpoint commit and is intentionally based on #23 as the fourth layer of native GitHub stack #24.