### PR TITLE
Project Tom Hagen: bind positional arguments

### DIFF
--- a/docs/binding.md
+++ b/docs/binding.md
@@ -284,7 +284,7 @@ function bindPhase(options: BindPhaseOptions): PhaseBinding {
         range: segment.range,
         through: horizon?.index,
       });
-      let read = param.cli(view);
+      let read = param.cli.read(view);
 
       if (read.result.ok && !read.result.value.exists) {
         continue;

--- a/docs/binding.md
+++ b/docs/binding.md
@@ -117,9 +117,8 @@ argv:    -c   app.json   auth0  --port   9001
 view:                    [---] |--- hidden ---|
 ```
 
-Nothing in the current phase claims `auth0`, so the horizon remains unchanged
-after a complete parameter sweep. CLI binding has reached a fixed point and must
-stop.
+Nothing in the current phase offers a claim for `auth0`. CLI binding has reached
+a fixed point and must stop.
 
 If `resume()` introduces an `auth0` route, route search can now claim index 2 as
 its selector. The child receives `--port 9001`. Without the horizon, a parent
@@ -157,8 +156,32 @@ moves to `auth0`:
                                horizon
 ```
 
-No parameter claims it, so the horizon is stable and CLI binding stops. This is
-a fixed-point calculation rather than an ordinary left-to-right cursor.
+No parameter offers a claim for it, so CLI binding stops. This is a fixed-point
+calculation rather than an ordinary left-to-right cursor.
+
+### Competing claims
+
+Every pending reader inspects the same immutable view before any claim is
+committed. If several readers offer claims, the claim beginning earliest in the
+original argv wins. Exact ties preserve parameter declaration order.
+
+For example:
+
+```text
+argv:       --port  9000  input.txt
+option:     [-----------]
+argument:           [--]
+```
+
+The option wins because its claim begins at `--port`; the positional reader
+cannot steal `9000`. On the next step, the argument claims `input.txt`. Two
+positional readers instead offer the same word, so their declaration order
+decides which one receives it.
+
+This arbitration comes entirely from proposed claims. Readers carry no
+option-versus-argument tag, and custom readers participate in exactly the same
+protocol. Failed reads compete normally, ensuring an invalid option still owns
+the tokens it captured.
 
 Route search always runs before phase binding. A currently discoverable route
 therefore beats an option value. A route introduced only after the current
@@ -251,23 +274,33 @@ function bindPhase(options: BindPhaseOptions): PhaseBinding {
     pending.delete(param.name);
   }
 
-  // Positional source: expand safe lookahead to a fixed point.
+  // Positional source: arbitrate claims until no reader can make progress.
   while (true) {
-    let before = firstWord(rest.tokens, segment.range);
+    let horizon = firstWord(rest.tokens, segment.range);
+    let offer;
 
     for (let param of pending.values()) {
       let view = rest.tokens.view({
         range: segment.range,
-        through: before?.index,
+        through: horizon?.index,
       });
+      let read = param.cli(view);
 
-      accept(param, fromCLI({ param, view, rest }));
+      if (read.result.ok && !read.result.value.exists) {
+        continue;
+      }
+
+      let index = earliest(read.claim.tokens);
+      if (!offer || index < offer.index) {
+        offer = { param, read, index };
+      }
     }
 
-    let after = firstWord(rest.tokens, segment.range);
-    if (after?.index === before?.index) {
+    if (!offer) {
       break;
     }
+
+    accept(offer.param, fromRead(offer.param, offer.read, rest));
   }
 
   // Stable address sources: array order is precedence.
@@ -298,12 +331,12 @@ function bindPhase(options: BindPhaseOptions): PhaseBinding {
 
 The source-outer address loop makes precedence explicit. Deleting a parameter
 from `pending` on every existing attempt prevents fallback after invalid input.
-Comparing the first remaining word before and after a sweep expresses the fixed
-point directly and removes `has()` and `next()` cursor bookkeeping.
+Recomputing proposals after each committed claim advances the horizon without
+letting one reader observe another reader's speculative remainder.
 
-When the final word is consumed, the changed before/after comparison causes one
-additional unbounded sweep. That sweep exposes trailing flags or setters. With
-no remaining words before or after it, the next comparison terminates.
+When the final word is consumed, the absent horizon creates an unbounded view,
+which exposes trailing flags or setters. The loop terminates when no reader
+offers another claim.
 
 ## Parser integration
 
@@ -353,6 +386,9 @@ The design should be established with observable tests for these cases:
 - Consuming the horizon exposes the next word and retries previously absent
   parameters.
 - A stable horizon leaves the entire suffix untouched.
+- A named option claim outranks an overlapping positional claim without reader
+  metadata.
+- Positional readers retain declaration order when they offer the same word.
 - CLI overrides Values even when its option is not visible until a later sweep.
 - Env overrides Values when that is the declared source order.
 - Invalid CLI blocks valid Env and Values.

--- a/lib/argument.ts
+++ b/lib/argument.ts
@@ -6,10 +6,11 @@ import {
   type ParamElement,
   type Unary,
 } from "./pipeline.ts";
-import { cli } from "./read.ts";
+import type { CLIRead, ReadCLI } from "./read.ts";
+import type { Word } from "./tokenize.ts";
 import type { AnyRoute, Definition } from "./types.ts";
 
-export function option<
+export function argument<
   const N extends string,
   const E extends readonly Unary[],
 >(
@@ -18,7 +19,7 @@ export function option<
 ): ElementOf<N, Fold<Param<N, unknown>, E>> {
   const added = elements.reduce<unknown>(
     (value, element) => element(value as never),
-    param(named, cli([`--${named.name}`])),
+    param(named, positional),
   ) as Param<string, unknown>;
 
   return brand<ElementOf<N, Fold<Param<N, unknown>, E>>>(
@@ -32,6 +33,7 @@ export function option<
           [added.name]: added,
         },
       });
+
       return {
         ...route,
         phases,
@@ -45,3 +47,36 @@ type ValueOf<P> = P extends Param<string, infer T> ? T : never;
 type ElementOf<N extends string, P> = P extends Param<N, unknown>
   ? ParamElement<N, ValueOf<P>>
   : never;
+
+function positional<P extends Param<string, unknown>>(param: P): P {
+  return { ...param, cli: read };
+}
+
+const read: ReadCLI = (tokens): CLIRead => {
+  let claim = tokens.claimOne((token): token is Word => token.type === "word");
+  let [word] = claim.tokens;
+
+  return word
+    ? {
+      claim,
+      result: {
+        ok: true,
+        value: { exists: true, value: word.text },
+        issues: [],
+      },
+    }
+    : nothing(tokens);
+};
+
+function nothing(tokens: Parameters<ReadCLI>[0]): CLIRead {
+  let claim = tokens.claimAll(() => false);
+
+  return {
+    claim,
+    result: {
+      ok: true,
+      value: { exists: false },
+      issues: [],
+    },
+  };
+}

--- a/lib/argument.ts
+++ b/lib/argument.ts
@@ -49,7 +49,16 @@ type ElementOf<N extends string, P> = P extends Param<N, unknown>
   : never;
 
 function positional<P extends Param<string, unknown>>(param: P): P {
-  return { ...param, cli: read };
+  return {
+    ...param,
+    cli: {
+      read,
+      syntax: {
+        type: "argument",
+        label: `<${param.name.toUpperCase()}>`,
+      },
+    },
+  };
 }
 
 const read: ReadCLI = (tokens): CLIRead => {

--- a/lib/bind.ts
+++ b/lib/bind.ts
@@ -30,7 +30,7 @@ export function fromCLI<const K extends string, T>(options: {
   readonly rest: Rest;
 }): Maybe<Binding<T>> {
   let { param, view, rest } = options;
-  return fromRead(param, param.cli(view), rest);
+  return fromRead(param, param.cli.read(view), rest);
 }
 
 export function fromValues<const K extends string, T>(options: {
@@ -138,7 +138,7 @@ export function bindPhase(options: {
         range: segment.range,
         through: horizon?.index,
       });
-      let read = param.cli(view);
+      let read = param.cli.read(view);
 
       if (read.result.ok && !read.result.value.exists) {
         continue;

--- a/lib/bind.ts
+++ b/lib/bind.ts
@@ -1,6 +1,6 @@
 import type { Maybe } from "./maybe.ts";
 import type { Param } from "./param.ts";
-import type { Symbol } from "./read.ts";
+import type { CLIRead, Symbol } from "./read.ts";
 import type { Rest } from "./rest.ts";
 import type { Result } from "./result.ts";
 import type { Word } from "./tokenize.ts";
@@ -30,43 +30,7 @@ export function fromCLI<const K extends string, T>(options: {
   readonly rest: Rest;
 }): Maybe<Binding<T>> {
   let { param, view, rest } = options;
-  let path = [param.name];
-  let read = param.cli(view);
-
-  if (!read.result.ok) {
-    return {
-      exists: true,
-      value: {
-        rest: {
-          ...rest,
-          tokens: read.claim.rest,
-        },
-        result: read.result,
-      },
-    };
-  }
-
-  if (!read.result.value.exists) {
-    return { exists: false };
-  }
-
-  let value = read.result.value.value;
-  let candidates = typeof value === "string" ? param.decode(value) : [value];
-  let result = merge(
-    decode(param, value, candidates, path),
-    read.result.issues,
-  );
-
-  return {
-    exists: true,
-    value: {
-      rest: {
-        ...rest,
-        tokens: read.claim.rest,
-      },
-      result,
-    },
-  };
+  return fromRead(param, param.cli(view), rest);
 }
 
 export function fromValues<const K extends string, T>(options: {
@@ -137,6 +101,15 @@ export function bindPhase(options: {
   let pending = new Map(params.map((param) => [param.name, param]));
   let results = new Map<string, Result<unknown>>();
 
+  function settle(
+    param: Param<string, unknown>,
+    binding: Binding<unknown>,
+  ): void {
+    rest = binding.rest;
+    results.set(param.name, binding.result);
+    pending.delete(param.name);
+  }
+
   function accept(
     param: Param<string, unknown>,
     attempt: Maybe<Binding<unknown>>,
@@ -145,34 +118,43 @@ export function bindPhase(options: {
       return;
     }
 
-    rest = attempt.value.rest;
-    results.set(param.name, attempt.value.result);
-    pending.delete(param.name);
+    settle(param, attempt.value);
   }
 
-  // CLI visibility grows whenever a parameter consumes the current horizon.
-  // Keep retrying provisional misses until a complete sweep leaves the first
-  // remaining word unchanged.
+  // Every pending reader proposes a claim against the same immutable view.
+  // Commit the proposal beginning earliest in argv, then recompute the view.
+  // This lets `--port 9000` outrank a positional claim on `9000` without
+  // attaching binding-policy metadata to either reader.
   while (true) {
-    let before = first(rest.tokens, segment.range);
+    let horizon = first(rest.tokens, segment.range);
+    let offer: {
+      param: Param<string, unknown>;
+      read: CLIRead;
+      index: number;
+    } | undefined;
 
     for (let param of pending.values()) {
-      let attempt = fromCLI({
-        param,
-        view: rest.tokens.view({
-          range: segment.range,
-          through: before?.index,
-        }),
-        rest,
+      let view = rest.tokens.view({
+        range: segment.range,
+        through: horizon?.index,
       });
+      let read = param.cli(view);
 
-      accept(param, attempt);
+      if (read.result.ok && !read.result.value.exists) {
+        continue;
+      }
+
+      let index = earliest(read.claim.tokens);
+      if (!offer || index < offer.index) {
+        offer = { param, read, index };
+      }
     }
 
-    let after = first(rest.tokens, segment.range);
-    if (after?.index === before?.index) {
+    if (!offer) {
       break;
     }
+
+    accept(offer.param, fromRead(offer.param, offer.read, rest));
   }
 
   // Address sources have stable visibility once the route is known. They are
@@ -215,6 +197,49 @@ export function bindPhase(options: {
   }
 
   return { rest, model, issues, valid };
+}
+
+function fromRead<T>(
+  param: Param<string, T>,
+  read: CLIRead,
+  rest: Rest,
+): Maybe<Binding<T>> {
+  let path = [param.name];
+
+  if (!read.result.ok) {
+    return {
+      exists: true,
+      value: {
+        rest: {
+          ...rest,
+          tokens: read.claim.rest,
+        },
+        result: read.result,
+      },
+    };
+  }
+
+  if (!read.result.value.exists) {
+    return { exists: false };
+  }
+
+  let value = read.result.value.value;
+  let candidates = typeof value === "string" ? param.decode(value) : [value];
+  let result = merge(
+    decode(param, value, candidates, path),
+    read.result.issues,
+  );
+
+  return {
+    exists: true,
+    value: {
+      rest: {
+        ...rest,
+        tokens: read.claim.rest,
+      },
+      result,
+    },
+  };
 }
 
 function decode<T>(
@@ -303,4 +328,14 @@ function first(tokens: Tokenizer<Symbol>, range: TokenRange): Word | undefined {
       return token;
     }
   }
+}
+
+function earliest(tokens: readonly Symbol[]): number {
+  let first = Infinity;
+
+  for (let token of tokens) {
+    first = Math.min(first, token.index);
+  }
+
+  return first;
 }

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -28,8 +28,10 @@ export interface EnvClaimOptions {
 
 export function env(
   key: string,
-): <P extends Param<string, unknown>>(param: P) => P {
-  return (param) => ({ ...param, env: key });
+): IdentityElement<Param<string, unknown>> {
+  return brand<IdentityElement<Param<string, unknown>>>(
+    (param: Param<string, unknown>) => ({ ...param, env: key }),
+  );
 }
 
 export function withEnvs(

--- a/lib/param.ts
+++ b/lib/param.ts
@@ -1,7 +1,13 @@
 import { type Decoder, scalar } from "./decode.ts";
+import {
+  type Check,
+  type Fold,
+  mark,
+  type Transform,
+  type TransformElement,
+  type Unary,
+} from "./pipeline.ts";
 import type { ReadCLI } from "./read.ts";
-import type { AnyToken } from "./tokenize.ts";
-import type { TokenInput } from "./tokenizer.ts";
 import type { Definition, Schema } from "./types.ts";
 
 export interface Param<K extends string, T> extends Definition<K> {
@@ -11,154 +17,49 @@ export interface Param<K extends string, T> extends Definition<K> {
   env?: string;
 }
 
-export function param<const K extends string>(
-  start: Definition<K>,
-): Param<K, unknown>;
-
-export function param<const K extends string, A>(
-  start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-): A;
-
-export function param<const K extends string, A, B>(
-  start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-  ab: (value: A) => B,
-): B;
-
-export function param<const K extends string, A, B, C>(
-  start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-): C;
-
-export function param<const K extends string, A, B, C, D>(
-  start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-): D;
-
-export function param<const K extends string, A, B, C, D, E>(
-  start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-): E;
-
-export function param<const K extends string, A, B, C, D, E, F>(
-  start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-  ef: (value: E) => F,
-): F;
-
 export function param<
   const K extends string,
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
+  const E extends readonly Unary[],
 >(
   start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-  ef: (value: E) => F,
-  fg: (value: F) => G,
-): G;
-
-export function param<
-  const K extends string,
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
->(
-  start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-  ef: (value: E) => F,
-  fg: (value: F) => G,
-  gh: (value: G) => H,
-): H;
-
-export function param<
-  const K extends string,
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
->(
-  start: Definition<K>,
-  ka: (value: Param<K, unknown>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-  ef: (value: E) => F,
-  fg: (value: F) => G,
-  gh: (value: G) => H,
-  hi: (value: H) => I,
-): I;
-
-export function param(
-  start: Definition<string>,
-  ...elements: readonly ((value: never) => unknown)[]
-): unknown {
-  let zero = {
+  ...elements: E & Check<Param<K, unknown>, E>
+): Fold<Param<K, unknown>, E> {
+  let zero: Param<K, unknown> = {
     ...start,
     schema: unknown,
-    cli: (tokens: TokenInput<AnyToken>) => ({
-      result: {
-        ok: true,
-        value: { exists: false },
-        issues: [],
-      },
-      claim: {
-        tokens: [],
-        rest: tokens,
-      },
-    }),
+    cli: (tokens) => {
+      let claim = tokens.claimAll(() => false);
+      return {
+        result: {
+          ok: true,
+          value: { exists: false },
+          issues: [],
+        },
+        claim,
+      };
+    },
     decode: scalar,
   };
+
   return elements.reduce<unknown>(
     (value, element) => element(value as never),
     zero,
-  );
+  ) as Fold<Param<K, unknown>, E>;
 }
 
 export function schema<T>(
   schema: Schema<T>,
-): <const P extends Param<string, unknown>>(param: P) => Param<P["name"], T> {
-  return (param) => ({
+): TransformElement<SchemaTransform<T>> {
+  return mark<SchemaTransform<T>>((param: Param<string, unknown>) => ({
     ...param,
     schema,
-  });
+  }));
+}
+
+interface SchemaTransform<T> extends Transform {
+  readonly input: Param<string, unknown>;
+  readonly output: this["input"] extends Param<infer N, unknown> ? Param<N, T>
+    : never;
 }
 
 const unknown: Schema<unknown> = {

--- a/lib/param.ts
+++ b/lib/param.ts
@@ -7,12 +7,12 @@ import {
   type TransformElement,
   type Unary,
 } from "./pipeline.ts";
-import type { ReadCLI } from "./read.ts";
+import type { CLIBinding } from "./read.ts";
 import type { Definition, Schema } from "./types.ts";
 
 export interface Param<K extends string, T> extends Definition<K> {
   schema: Schema<T>;
-  cli: ReadCLI;
+  cli: CLIBinding;
   decode: Decoder;
   env?: string;
 }
@@ -27,16 +27,18 @@ export function param<
   let zero: Param<K, unknown> = {
     ...start,
     schema: unknown,
-    cli: (tokens) => {
-      let claim = tokens.claimAll(() => false);
-      return {
-        result: {
-          ok: true,
-          value: { exists: false },
-          issues: [],
-        },
-        claim,
-      };
+    cli: {
+      read(tokens) {
+        let claim = tokens.claimAll(() => false);
+        return {
+          result: {
+            ok: true,
+            value: { exists: false },
+            issues: [],
+          },
+          claim,
+        };
+      },
     },
     decode: scalar,
   };

--- a/lib/print.ts
+++ b/lib/print.ts
@@ -3,8 +3,6 @@
  */
 
 import type { Param } from "./param.ts";
-import type { Flag } from "./tokenize.ts";
-import { Tokenizer } from "./tokenizer.ts";
 import type {
   AnyRoute,
   Help,
@@ -21,8 +19,27 @@ export function printHelp<
   let route = intent.definition;
   let subject = title(intent);
   let heading = route.version ? `${subject} ${route.version}` : subject;
-  let usage = `${subject} [OPTIONS]`;
   let children = route.phases.flatMap((phase) => phase.routes);
+  let args: Row[] = [];
+  let options: Row[] = [];
+
+  for (let param of params(route)) {
+    let syntax = param.cli.syntax;
+    if (!syntax) {
+      continue;
+    }
+
+    let row: Row = [syntax.label, param.description];
+    if (syntax.type === "argument") {
+      args.push(row);
+    } else {
+      options.push(row);
+    }
+  }
+
+  let usage = [subject, "[OPTIONS]", ...args.map(([label]) => label)].join(
+    " ",
+  );
 
   if (children.length > 0) {
     usage += route.methods.includes("execute") ? " [COMMAND]" : " <COMMAND>";
@@ -35,6 +52,10 @@ export function printHelp<
 
   lines.push("", "Usage:", `  ${usage}`);
 
+  if (args.length > 0) {
+    lines.push("", "Arguments:", ...list(args));
+  }
+
   if (children.length > 0) {
     lines.push(
       "",
@@ -42,11 +63,6 @@ export function printHelp<
       ...list(children.map((child) => [child.name, child.description])),
     );
   }
-
-  let options: Row[] = params(route).map((param) => [
-    label(param),
-    param.description,
-  ]);
 
   options.push(["-h, --help", "Print help"]);
   if (route.methods.includes("version")) {
@@ -147,45 +163,6 @@ function wrap(text: string, size: number): string[] {
   }
 
   return lines;
-}
-
-function label(param: Param<string, unknown>): string {
-  let stem = dash(param.name);
-  let yes = `--${stem}`;
-  let no = `--no-${stem}`;
-  let positive = boolean(param, yes);
-  let negative = boolean(param, no);
-
-  return typeof positive === "boolean"
-    ? negative === false ? `${yes}, ${no}` : yes
-    : `--${param.name} <VALUE>`;
-}
-
-function boolean(
-  param: Param<string, unknown>,
-  text: string,
-): boolean | undefined {
-  let flag: Flag = {
-    type: "flag",
-    index: 0,
-    text,
-    flagText: text.slice(text.startsWith("--") ? 2 : 1),
-    flagType: text.startsWith("--") ? "long" : "short",
-  };
-  let read = param.cli(new Tokenizer([flag]));
-
-  return read.result.ok && read.result.value.exists &&
-      typeof read.result.value.value === "boolean"
-    ? read.result.value.value
-    : undefined;
-}
-
-function dash(name: string): string {
-  return name
-    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1-$2")
-    .replace(/([a-z\d])([A-Z])/g, "$1-$2")
-    .replace(/[\s_]+/g, "-")
-    .toLowerCase();
 }
 
 function problem(issue: Issue): string {

--- a/lib/print.ts
+++ b/lib/print.ts
@@ -16,7 +16,7 @@ import type {
 } from "./types.ts";
 
 export function printHelp<
-  const H extends Help<AnyRoute, RoutePath>,
+  const H extends Help<RoutePath>,
 >(intent: H): string {
   let route = intent.definition;
   let subject = title(intent);
@@ -59,7 +59,7 @@ export function printHelp<
 }
 
 export function printVersion<
-  const V extends Version<AnyRoute, RoutePath>,
+  const V extends Version<RoutePath>,
 >(intent: V): string {
   let version = intent.definition.version;
   if (!version) {

--- a/lib/read.ts
+++ b/lib/read.ts
@@ -1,5 +1,6 @@
 import type { Maybe } from "./maybe.ts";
 import type { Param } from "./param.ts";
+import { brand, type IdentityElement } from "./pipeline.ts";
 import type { Result } from "./result.ts";
 import type { Flag, Setter, Word } from "./tokenize.ts";
 import type { Claim, TokenInput } from "./tokenizer.ts";
@@ -22,7 +23,7 @@ export interface CLIOptions {
 export function cli(
   names: string[],
   options: CLIOptions = {},
-): <P extends Param<string, unknown>>(param: P) => P {
+): IdentityElement<Param<string, unknown>> {
   const read: ReadCLI = (tokens) => {
     if (options.switch) {
       let s = tokens.claimOne((t): t is Flag => {
@@ -93,10 +94,12 @@ export function cli(
     return nothing(tokens);
   };
 
-  return (param) => ({
-    ...param,
-    cli: read,
-  });
+  return brand<IdentityElement<Param<string, unknown>>>(
+    (param: Param<string, unknown>) => ({
+      ...param,
+      cli: read,
+    }),
+  );
 }
 
 function nothing(tokenizer: TokenInput<Symbol>): CLIRead {

--- a/lib/read.ts
+++ b/lib/read.ts
@@ -11,6 +11,15 @@ export type ReadCLI = (
   tokens: TokenInput<Symbol>,
 ) => CLIRead;
 
+export interface CLIBinding {
+  readonly read: ReadCLI;
+  readonly syntax?: CLISyntax;
+}
+
+export type CLISyntax =
+  | { readonly type: "argument"; readonly label: string }
+  | { readonly type: "option"; readonly label: string };
+
 export interface CLIRead {
   result: Result<Maybe<string | boolean>>;
   claim: Claim<Symbol>;
@@ -21,7 +30,7 @@ export interface CLIOptions {
 }
 
 export function cli(
-  names: string[],
+  names: readonly string[],
   options: CLIOptions = {},
 ): IdentityElement<Param<string, unknown>> {
   const read: ReadCLI = (tokens) => {
@@ -97,7 +106,15 @@ export function cli(
   return brand<IdentityElement<Param<string, unknown>>>(
     (param: Param<string, unknown>) => ({
       ...param,
-      cli: read,
+      cli: {
+        read,
+        syntax: {
+          type: "option",
+          label: options.switch
+            ? names.join(", ")
+            : `${names.join(", ")} <VALUE>`,
+        },
+      },
     }),
   );
 }

--- a/lib/toggle.ts
+++ b/lib/toggle.ts
@@ -55,8 +55,20 @@ type ElementOf<N extends string, P> = P extends Param<N, unknown>
 function binding(
   name: string,
 ): <P extends Param<string, unknown>>(param: P) => P {
-  const cli = reader(name);
-  return (param) => ({ ...param, cli });
+  const stem = dash(name);
+  const yes = `--${stem}`;
+  const no = `--no-${stem}`;
+
+  return (param) => ({
+    ...param,
+    cli: {
+      read: reader(name),
+      syntax: {
+        type: "option",
+        label: `${yes}, ${no}`,
+      },
+    },
+  });
 }
 
 function reader(name: string): ReadCLI {

--- a/lib/toggle.ts
+++ b/lib/toggle.ts
@@ -1,120 +1,23 @@
 import { boolean as decode } from "./decode.ts";
 import { type Param, param, schema } from "./param.ts";
-import { brand, type ParamElement } from "./pipeline.ts";
+import {
+  brand,
+  type Check,
+  type Fold,
+  type ParamElement,
+  type Unary,
+} from "./pipeline.ts";
 import type { CLIRead, ReadCLI } from "./read.ts";
 import type { Flag } from "./tokenize.ts";
 import type { AnyRoute, Definition, Schema } from "./types.ts";
 
-export function toggle<const N extends string>(
-  named: Definition<N>,
-): ParamElement<N, boolean>;
-
-export function toggle<const N extends string, T>(
-  named: Definition<N>,
-  nt: (value: Param<N, boolean>) => Param<N, T>,
-): ParamElement<N, T>;
-
-export function toggle<const N extends string, A, T>(
-  named: Definition<N>,
-  na: (value: Param<N, boolean>) => A,
-  at: (value: A) => Param<N, T>,
-): ParamElement<N, T>;
-
-export function toggle<const N extends string, A, B, T>(
-  named: Definition<N>,
-  na: (value: Param<N, boolean>) => A,
-  ab: (value: A) => B,
-  bt: (value: B) => Param<N, T>,
-): ParamElement<N, T>;
-
-export function toggle<const N extends string, A, B, C, T>(
-  named: Definition<N>,
-  na: (value: Param<N, boolean>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  ct: (value: C) => Param<N, T>,
-): ParamElement<N, T>;
-
-export function toggle<const N extends string, A, B, C, D, T>(
-  named: Definition<N>,
-  na: (value: Param<N, boolean>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  dt: (value: D) => Param<N, T>,
-): ParamElement<N, T>;
-
-export function toggle<const N extends string, A, B, C, D, E, T>(
-  named: Definition<N>,
-  na: (value: Param<N, boolean>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-  et: (value: E) => Param<N, T>,
-): ParamElement<N, T>;
-
-export function toggle<const N extends string, A, B, C, D, E, F, T>(
-  named: Definition<N>,
-  na: (value: Param<N, boolean>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-  ef: (value: E) => F,
-  ft: (value: F) => Param<N, T>,
-): ParamElement<N, T>;
-
 export function toggle<
   const N extends string,
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  T,
+  const E extends readonly Unary[],
 >(
   named: Definition<N>,
-  na: (value: Param<N, boolean>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-  ef: (value: E) => F,
-  fg: (value: F) => G,
-  gt: (value: G) => Param<N, T>,
-): ParamElement<N, T>;
-
-export function toggle<
-  const N extends string,
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  T,
->(
-  named: Definition<N>,
-  na: (value: Param<N, boolean>) => A,
-  ab: (value: A) => B,
-  bc: (value: B) => C,
-  cd: (value: C) => D,
-  de: (value: D) => E,
-  ef: (value: E) => F,
-  fg: (value: F) => G,
-  gh: (value: G) => H,
-  ht: (value: H) => Param<N, T>,
-): ParamElement<N, T>;
-
-export function toggle(
-  named: Definition<string>,
-  ...elements: readonly ((value: never) => unknown)[]
-): unknown {
+  ...elements: E & Check<Param<N, boolean>, E>
+): ElementOf<N, Fold<Param<N, boolean>, E>> {
   const added = elements.reduce<unknown>(
     (value, element) => element(value as never),
     {
@@ -123,23 +26,31 @@ export function toggle(
     },
   ) as Param<string, unknown>;
 
-  return brand<ParamElement<string, unknown>>((route: AnyRoute) => {
-    let phases = [...route.phases];
-    let phase = phases.pop()!;
-    phases.push({
-      ...phase,
-      params: {
-        ...phase.params,
-        [added.name]: added,
-      },
-    });
+  return brand<ElementOf<N, Fold<Param<N, boolean>, E>>>(
+    (route: AnyRoute) => {
+      let phases = [...route.phases];
+      let phase = phases.pop()!;
+      phases.push({
+        ...phase,
+        params: {
+          ...phase.params,
+          [added.name]: added,
+        },
+      });
 
-    return {
-      ...route,
-      phases,
-    };
-  });
+      return {
+        ...route,
+        phases,
+      };
+    },
+  );
 }
+
+type ValueOf<P> = P extends Param<string, infer T> ? T : never;
+
+type ElementOf<N extends string, P> = P extends Param<N, unknown>
+  ? ParamElement<N, ValueOf<P>>
+  : never;
 
 function binding(
   name: string,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -161,53 +161,49 @@ export type PathOf<R extends RoutePath> = R extends "/" ? []
   : never;
 
 export type AnyIntent =
-  | Help<AnyRoute, RoutePath>
-  | Version<AnyRoute, RoutePath>
-  | Execute<AnyRoute, RoutePath, ModelsByRoute>;
+  | Help<RoutePath>
+  | Version<RoutePath>
+  | Execute<RoutePath, ModelsByRoute>;
 
 export type ChildIntents<
   C extends readonly AnyRoute[],
   P extends RoutePath,
-  T extends ModelsByRoute,
+  Models extends ModelsByRoute,
 > = C extends readonly [
   infer Head extends AnyRoute,
   ...infer Tail extends readonly AnyRoute[],
 ] ? (
-    | IntentsAt<Head, Append<P, Head["name"]>, T>
-    | ChildIntents<Tail, P, T>
+    | IntentsAt<Head, Append<P, Head["name"]>, Models>
+    | ChildIntents<Tail, P, Models>
   )
   : never;
 
 export interface Intent<
   M extends Method,
-  R extends AnyRoute,
   P extends RoutePath,
 > {
   readonly ok: true;
   readonly method: M;
   readonly route: P;
-  readonly definition: R;
+  readonly definition: AnyRoute;
   readonly path: PathOf<P>;
   readonly literals: Iterable<Literal>;
 }
 
-export type Help<R extends AnyRoute, P extends RoutePath> = Intent<
+export type Help<P extends RoutePath> = Intent<
   "help",
-  R,
   P
 >;
 
-export type Version<R extends AnyRoute, P extends RoutePath> = Intent<
+export type Version<P extends RoutePath> = Intent<
   "version",
-  R,
   P
 >;
 
 export interface Execute<
-  R extends AnyRoute,
   P extends RoutePath,
   Models extends ModelsByRoute,
-> extends Intent<"execute", R, P> {
+> extends Intent<"execute", P> {
   readonly issues: readonly Issue[];
   readonly model: Models[P];
   readonly models: Models;
@@ -251,14 +247,30 @@ type ParseAt<
   P extends RoutePath,
   Models extends ModelsByRoute,
 > = [RequirementOf<R>] extends [never] ? (
-    | RouteIntents<R, P, AddModel<Models, P, ModelOf<R>>>
+    | Help<P>
+    | (
+      "version" extends MethodsOf<R> ? Version<P>
+        : never
+    )
+    | (
+      "execute" extends MethodsOf<R> ? AddModel<
+          Models,
+          P,
+          ModelOf<R>
+        > extends infer Bound extends ModelsByRoute ? Execute<
+            P,
+            { [K in keyof Bound]: Bound[K] }
+          >
+        : never
+        : never
+    )
     | ParseChildren<
       ChildrenOf<R>,
       P,
       AddModel<Models, P, ModelOf<R>>
     >
   )
-  : ParseIncrement<R, P, Models>;
+  : ParseIncrement<R, P, { [K in keyof Models]: Models[K] }>;
 
 type ParseChildren<
   C extends readonly AnyRoute[],
@@ -281,11 +293,13 @@ type RequirementsIn<P extends readonly AnyPhase[]> = P extends readonly [
   : readonly [];
 
 type AddModel<
-  M extends ModelsByRoute,
+  Models extends ModelsByRoute,
   P extends RoutePath,
   T extends object,
 > = {
-  [K in keyof M | P]: K extends P ? T : K extends keyof M ? M[K] : never;
+  [K in keyof Models | P]: K extends P ? T
+    : K extends keyof Models ? Models[K]
+    : never;
 };
 
 type Split<S extends string> = string extends S ? Path
@@ -381,20 +395,25 @@ type IntentsAt<
   P extends RoutePath,
   Models extends ModelsByRoute,
 > =
-  | RouteIntents<R, P, AddModel<Models, P, ModelOf<R>>>
-  | ChildIntents<ChildrenOf<R>, P, AddModel<Models, P, ModelOf<R>>>;
-
-type RouteIntents<
-  R extends AnyRoute,
-  P extends RoutePath,
-  T extends ModelsByRoute,
-> =
-  | Help<R, P>
+  | Help<P>
   | (
-    "version" extends MethodsOf<R> ? Version<R, P>
+    "version" extends MethodsOf<R> ? Version<P>
       : never
   )
   | (
-    "execute" extends MethodsOf<R> ? Execute<R, P, T>
+    "execute" extends MethodsOf<R> ? AddModel<
+        Models,
+        P,
+        ModelOf<R>
+      > extends infer Bound extends ModelsByRoute ? Execute<
+          P,
+          { [K in keyof Bound]: Bound[K] }
+        >
       : never
-  );
+      : never
+  )
+  | ChildIntents<
+    ChildrenOf<R>,
+    P,
+    AddModel<Models, P, ModelOf<R>>
+  >;

--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,5 @@
+export { argument } from "./lib/argument.ts";
+
 export { extend } from "./lib/extend.ts";
 export { command } from "./lib/command.ts";
 export type { CommandZero } from "./lib/command.ts";

--- a/test/argument.test.ts
+++ b/test/argument.test.ts
@@ -1,0 +1,338 @@
+import { describe, it } from "@std/testing/bdd";
+import { expect } from "@std/expect";
+import { type } from "arktype";
+import {
+  argument,
+  command,
+  extend,
+  type ModelOf,
+  name,
+  option,
+  parse,
+  routes,
+  schema,
+  toggle,
+} from "@frontside/configliere";
+import { dynamic } from "../lib/dynamic.ts";
+
+describe("argument()", () => {
+  describe("types", () => {
+    it("adds its exact schema output to the route model", () => {
+      let app = command(
+        name("copy"),
+        argument(name("source"), schema(type("string"))),
+        argument(name("destination"), schema(type("string"))),
+      );
+
+      expectType<
+        Equal<
+          ModelOf<typeof app>,
+          { source: string; destination: string }
+        >
+      >(true);
+    });
+  });
+
+  describe("CLI binding", () => {
+    it("binds a positional word", () => {
+      let app = command(
+        name("copy"),
+        argument(name("source"), schema(type("string"))),
+      );
+      let result = parse(app, { argv: ["input.txt"] });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: { source: "input.txt" },
+      });
+    });
+
+    it("binds several arguments in declaration order", () => {
+      let app = command(
+        name("copy"),
+        argument(name("source"), schema(type("string"))),
+        argument(name("destination"), schema(type("string"))),
+      );
+      let result = parse(app, {
+        argv: ["input.txt", "output.txt"],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: {
+          source: "input.txt",
+          destination: "output.txt",
+        },
+      });
+    });
+
+    it("binds a positional word before a later option", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+        option(name("port"), schema(type("number"))),
+      );
+      let result = parse(app, {
+        argv: ["input.txt", "--port", "9000"],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { input: "input.txt", port: 9000 },
+      });
+    });
+
+    it.skip("does not let a positional reader steal an option value", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+        option(name("port"), schema(type("number"))),
+      );
+      let result = parse(app, {
+        argv: ["--port", "9000", "input.txt"],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { input: "input.txt", port: 9000 },
+      });
+    });
+
+    it("binds a positional word following a switch", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+        toggle(name("verbose")),
+      );
+      let result = parse(app, {
+        argv: ["--verbose", "input.txt"],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { input: "input.txt", verbose: true },
+      });
+    });
+  });
+
+  describe("routing", () => {
+    it("binds words on each side of a selector to their route segments", () => {
+      let auth0 = command(
+        name("auth0"),
+        argument(name("manifest"), schema(type("string"))),
+      );
+      let app = command(
+        name("app"),
+        argument(name("workspace"), schema(type("string"))),
+        routes(auth0),
+      );
+      let result = parse(app, {
+        argv: ["local", "auth0", "service.json"],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/auth0",
+        model: { manifest: "service.json" },
+        models: {
+          "/": { workspace: "local" },
+          "/auth0": { manifest: "service.json" },
+        },
+      });
+    });
+
+    it("gives a visible child selector priority over an argument", () => {
+      let auth0 = command(name("auth0"));
+      let app = command(
+        name("app"),
+        argument(name("workspace"), schema(type("string | undefined"))),
+        routes(auth0),
+      );
+      let result = parse(app, { argv: ["auth0"] });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/auth0",
+        models: {
+          "/": { workspace: undefined },
+          "/auth0": {},
+        },
+      });
+    });
+  });
+
+  describe("sources", () => {
+    it("prefers a positional CLI value over environment and values", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+      );
+      let result = parse(app, {
+        argv: ["cli.txt"],
+        envs: [{ name: "process", value: { INPUT: "env.txt" } }],
+        values: [{ name: "config", value: { input: "value.txt" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { input: "cli.txt" },
+      });
+    });
+
+    it("uses environment when the positional value is absent", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+      );
+      let result = parse(app, {
+        argv: [],
+        envs: [{ name: "process", value: { INPUT: "env.txt" } }],
+        values: [{ name: "config", value: { input: "value.txt" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { input: "env.txt" },
+      });
+    });
+
+    it("uses a JavaScript value when CLI and environment are absent", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+      );
+      let result = parse(app, {
+        argv: [],
+        values: [{ name: "config", value: { input: "value.txt" } }],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: { input: "value.txt" },
+      });
+    });
+  });
+
+  describe("validation", () => {
+    it("reports a missing required argument at its parameter address", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+      );
+      let result = parse(app, { argv: [] });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ path: ["input"] }],
+      });
+    });
+
+    it("reports a word left after all arguments are bound", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+      );
+      let result = parse(app, {
+        argv: ["input.txt", "extra.txt"],
+      });
+
+      expect(result).toMatchObject({
+        ok: false,
+        code: "unprocessable-content",
+        route: "/",
+        issues: [{ message: 'unexpected "extra.txt"' }],
+      });
+    });
+  });
+
+  describe("phases", () => {
+    it("lets a later phase bind an unclaimed argument on the same route", () => {
+      let app = command(
+        name("app"),
+        option(name("config"), schema(type("string"))),
+        dynamic(() =>
+          extend(
+            argument(name("input"), schema(type("string"))),
+          )
+        ),
+      );
+      let increment = parse(app, {
+        argv: ["--config", "app.json", "input.txt"],
+      });
+
+      expect(increment).toMatchObject({
+        ok: true,
+        route: "/",
+        model: { config: "app.json" },
+      });
+      assertIncrement(increment);
+
+      let result = increment.resume({ ok: true, value: undefined });
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: { config: "app.json", input: "input.txt" },
+      });
+    });
+
+    it("does not reinterpret an argument claimed before a route is introduced", () => {
+      let app = command(
+        name("app"),
+        argument(name("target"), schema(type("string"))),
+        dynamic(() =>
+          extend(
+            routes(command(name("auth0"))),
+          )
+        ),
+      );
+      let increment = parse(app, { argv: ["auth0"] });
+
+      expect(increment).toMatchObject({
+        ok: true,
+        route: "/",
+        model: { target: "auth0" },
+      });
+      assertIncrement(increment);
+
+      let result = increment.resume({ ok: true, value: undefined });
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        route: "/",
+        model: { target: "auth0" },
+      });
+    });
+  });
+});
+
+type Equal<L, R> = (<T>() => T extends L ? 1 : 2) extends
+  (<T>() => T extends R ? 1 : 2) ? true
+  : false;
+
+function expectType<T extends true>(_value: T): void {}
+
+function assertIncrement(
+  result: unknown,
+): asserts result is {
+  resume(result: { readonly ok: true; readonly value: undefined }): unknown;
+} {
+  expect(result).toMatchObject({ ok: true });
+  expect(
+    typeof (result as { readonly resume?: unknown }).resume,
+  ).toBe("function");
+}

--- a/test/argument.test.ts
+++ b/test/argument.test.ts
@@ -87,7 +87,7 @@ describe("argument()", () => {
       });
     });
 
-    it.skip("does not let a positional reader steal an option value", () => {
+    it("does not let a positional reader steal an option value", () => {
       let app = command(
         name("app"),
         argument(name("input"), schema(type("string"))),
@@ -101,6 +101,43 @@ describe("argument()", () => {
         ok: true,
         method: "execute",
         model: { input: "input.txt", port: 9000 },
+      });
+    });
+
+    it("keeps an invalid option value attached to its option", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+        option(name("port"), schema(type("number"))),
+      );
+      let result = parse(app, {
+        argv: ["--port", "nope", "input.txt"],
+      });
+
+      assertUnprocessable(result);
+      expect(result.issues).toHaveLength(1);
+      expect(result.issues[0]).toMatchObject({ path: ["port"] });
+    });
+
+    it("preserves positional order around an option", () => {
+      let app = command(
+        name("copy"),
+        argument(name("source"), schema(type("string"))),
+        option(name("port"), schema(type("number"))),
+        argument(name("destination"), schema(type("string"))),
+      );
+      let result = parse(app, {
+        argv: ["input.txt", "--port", "9000", "output.txt"],
+      });
+
+      expect(result).toMatchObject({
+        ok: true,
+        method: "execute",
+        model: {
+          source: "input.txt",
+          port: 9000,
+          destination: "output.txt",
+        },
       });
     });
 
@@ -257,6 +294,19 @@ describe("argument()", () => {
         issues: [{ message: 'unexpected "extra.txt"' }],
       });
     });
+
+    it("does not reserve an argument for an unknown flag", () => {
+      let app = command(
+        name("app"),
+        argument(name("input"), schema(type("string"))),
+      );
+      let result = parse(app, {
+        argv: ["--floop", "input.txt"],
+      });
+
+      assertUnprocessable(result);
+      expect(result.issues).toEqual([{ message: 'unexpected "--floop"' }]);
+    });
   });
 
   describe("phases", () => {
@@ -335,4 +385,16 @@ function assertIncrement(
   expect(
     typeof (result as { readonly resume?: unknown }).resume,
   ).toBe("function");
+}
+
+function assertUnprocessable(
+  result: unknown,
+): asserts result is {
+  readonly issues: readonly unknown[];
+} {
+  expect(result).toMatchObject({
+    ok: false,
+    code: "unprocessable-content",
+    route: "/",
+  });
 }

--- a/test/bind.test.ts
+++ b/test/bind.test.ts
@@ -125,20 +125,23 @@ describe("binding", () => {
       cli(["--port"]),
       schema(z.number()),
     );
-    let read = base.cli;
+    let read = base.cli.read;
     let port = {
       ...base,
-      cli(tokens: Parameters<typeof read>[0]) {
-        let capture = read(tokens);
-        return capture.result.ok
-          ? {
-            ...capture,
-            result: {
-              ...capture.result,
-              issues: [{ message: "--port is deprecated" }],
-            },
-          }
-          : capture;
+      cli: {
+        ...base.cli,
+        read(tokens: Parameters<typeof read>[0]) {
+          let capture = read(tokens);
+          return capture.result.ok
+            ? {
+              ...capture,
+              result: {
+                ...capture.result,
+                issues: [{ message: "--port is deprecated" }],
+              },
+            }
+            : capture;
+        },
       },
     };
     let result = bindPhase({

--- a/test/fold.test.ts
+++ b/test/fold.test.ts
@@ -396,6 +396,29 @@ describe("pipeline fold", () => {
     expectType<Equal<typeof extended, 11>>(true);
   });
 
+  it("folds parameter modifiers without an arity limit", () => {
+    let app = command(
+      name("app"),
+      option(
+        name("port"),
+        description("one"),
+        description("two"),
+        description("three"),
+        description("four"),
+        description("five"),
+        description("six"),
+        description("seven"),
+        description("eight"),
+        description("nine"),
+        description("ten"),
+        description("eleven"),
+        schema(type("number")),
+      ),
+    );
+
+    expectType<Equal<ModelOf<typeof app>, { port: number }>>(true);
+  });
+
   it("composes an identity macro between built-ins", () => {
     let identity = extend();
     let app = route(

--- a/test/print.test.ts
+++ b/test/print.test.ts
@@ -5,6 +5,7 @@
 import { expect } from "@std/expect";
 import { describe, it } from "@std/testing/bdd";
 import { type } from "arktype";
+import { argument } from "../lib/argument.ts";
 import { command } from "../lib/command.ts";
 import { description, name } from "../lib/definition.ts";
 import { option } from "../lib/option.ts";
@@ -79,6 +80,47 @@ Options:
   --verbose, --no-verbose  Show detailed startup and request diagnostics.
   -h, --help               Print help
   -v, --version            Print version`);
+  });
+
+  it("prints positional arguments in usage and their own section", () => {
+    let copy = command(
+      name("copy"),
+      description("Copy one file."),
+      argument(
+        name("source"),
+        description("File to copy."),
+        schema(type("string")),
+      ),
+      option(
+        name("format"),
+        description("Output format."),
+      ),
+      argument(
+        name("destination"),
+        description("Destination path."),
+        schema(type("string")),
+      ),
+    );
+    let result = parse(copy, { argv: ["--help"] });
+
+    expect(result).toMatchObject({ ok: true, method: "help" });
+    if (!result.ok || result.method !== "help") {
+      throw new Error("expected help");
+    }
+
+    expect(printHelp(result)).toBe(`copy
+Copy one file.
+
+Usage:
+  copy [OPTIONS] <SOURCE> <DESTINATION>
+
+Arguments:
+  <SOURCE>       File to copy.
+  <DESTINATION>  Destination path.
+
+Options:
+  --format <VALUE>  Output format.
+  -h, --help        Print help`);
   });
 
   it("prints help relative to a deeply nested route", () => {

--- a/test/read.test.ts
+++ b/test/read.test.ts
@@ -11,7 +11,7 @@ describe("CLI reader", () => {
     let read = param(
       name("port"),
       cli(["--port"]),
-    ).cli(symbols(["--port", "--verbose"]));
+    ).cli.read(symbols(["--port", "--verbose"]));
 
     expect(read.result).toMatchObject({
       ok: false,


### PR DESCRIPTION
## Stack

- Root: #20
- Dynamic phases: #22
- Source-aware binding: #23
- Environment sources: #25
- Parent: #26
- This PR: positional arguments

## What changed

- adds positional arguments as first-class parameter bindings
- binds words in declaration order without stealing option values
- gives visible child routes priority over positional arguments
- preserves CLI, environment, and JavaScript-value precedence
- renders positional arguments explicitly in usage and help
- keeps argument models and parse outcomes statically typed

## Verification

- deno task test — 243 passing steps
- deno lint lib test